### PR TITLE
Redesign authentication pages

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1049,104 +1049,337 @@ h2 {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #eef2ff, #e0f2fe);
+    padding: 2.5rem 1.5rem;
+    background:
+        radial-gradient(circle at 0% 0%, rgba(59, 130, 246, 0.18), transparent 55%),
+        radial-gradient(circle at 100% 100%, rgba(16, 185, 129, 0.18), transparent 55%),
+        linear-gradient(135deg, #eef2ff, #e0f2fe);
 }
 
-.auth-container {
-    width: min(420px, 90vw);
+.auth-wrapper {
+    width: min(1100px, 100%);
+    position: relative;
+    z-index: 1;
+}
+
+.auth-card {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     background: var(--bg-secondary);
-    border: 1px solid;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    border-radius: 1.75rem;
+    overflow: hidden;
+    box-shadow: var(--shadow-xl);
+}
+
+.auth-showcase {
+    padding: 3rem;
+    background: linear-gradient(150deg, var(--primary-dark), #2563eb 50%, var(--info-color));
+    color: #f8fafc;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    position: relative;
+    justify-content: space-between;
+}
+
+.auth-showcase::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
+        radial-gradient(circle at 80% 80%, rgba(14, 165, 233, 0.25), transparent 65%);
+    mix-blend-mode: screen;
+    pointer-events: none;
+}
+
+.auth-showcase > * {
+    position: relative;
+    z-index: 1;
+}
+
+.auth-brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.auth-logo {
+    width: 3.25rem;
+    height: 3.25rem;
+    display: grid;
+    place-items: center;
+    border-radius: 1rem;
+    background: rgba(15, 23, 42, 0.35);
+    color: #fff;
+    font-weight: 700;
+    font-size: 1.1rem;
+    letter-spacing: 0.08em;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+    text-transform: uppercase;
+}
+
+.auth-brand-text h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.auth-brand-text p {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.85);
+    font-weight: 500;
+}
+
+.auth-description {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: rgba(241, 245, 249, 0.9);
+}
+
+.auth-highlights {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.auth-highlights li {
+    position: relative;
+    padding-left: 1.9rem;
+    font-weight: 500;
+    line-height: 1.5;
+}
+
+.auth-highlights li::before {
+    content: "✓";
+    position: absolute;
+    left: 0;
+    top: 0.2rem;
+    width: 1.2rem;
+    height: 1.2rem;
+    border-radius: 50%;
+    background: rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    display: grid;
+    place-items: center;
+    font-size: 0.75rem;
+    color: #fff;
+    font-weight: 700;
+}
+
+.auth-progress {
+    margin-top: auto;
+    padding: 1.25rem;
+    border-radius: var(--radius-lg);
+    background: rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    backdrop-filter: blur(6px);
+}
+
+.auth-progress span {
+    font-size: 2.5rem;
+    font-weight: 700;
+    line-height: 1;
+    color: #fff;
+}
+
+.auth-progress p {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.9);
+    line-height: 1.5;
+}
+
+.auth-content {
+    padding: 3rem 3.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.auth-title {
+    font-size: 2.15rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.auth-subtitle {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.auth-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.auth-form .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.auth-form label {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+}
+
+.auth-form input {
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    background: #f8fafc;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    font-size: 0.95rem;
+}
+
+.auth-form input:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+    outline: none;
+    background: #fff;
+}
+
+.auth-form input::placeholder {
+    color: var(--text-secondary);
+    opacity: 0.7;
+}
+
+.field-error input {
+    border-color: var(--danger-color);
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}
+
+.field-error small {
+    color: var(--danger-color);
+    font-size: 0.85rem;
+}
+
+.auth-form .auth-alert {
+    margin-top: -0.25rem;
+}
+
+.auth-alert {
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-lg);
+    font-size: 0.92rem;
+    line-height: 1.5;
+    border: 1px solid transparent;
+}
+
+.auth-alert + .auth-alert {
+    margin-top: 0.5rem;
+}
+
+.auth-alert-success {
+    background: rgba(34, 197, 94, 0.12);
+    color: #15803d;
+    border-color: rgba(34, 197, 94, 0.35);
+}
+
+.auth-alert-danger {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+    border-color: rgba(239, 68, 68, 0.35);
+}
+
+.auth-submit {
+    width: 100%;
+    justify-content: center;
+    padding: 0.9rem 1.5rem;
+    font-size: 1rem;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(135deg, var(--primary-color), var(--primary-dark));
+    box-shadow: 0 12px 20px -12px rgba(59, 130, 246, 0.75);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.auth-submit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 30px -15px rgba(29, 78, 216, 0.55);
+    filter: brightness(1.05);
+}
+
+.auth-note {
+    margin-top: -0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+.auth-footer {
+    margin-top: 0.75rem;
+    color: var(--text-secondary);
+    text-align: center;
+    font-size: 0.95rem;
+}
+
+.auth-footer a {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.auth-footer a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 1024px) {
+    .auth-content {
+        padding: 2.5rem;
+    }
+
+    .auth-showcase {
+        padding: 2.5rem;
+    }
+}
+
+@media (max-width: 900px) {
+    .auth-card {
+        grid-template-columns: 1fr;
+    }
+
+    .auth-showcase {
+        border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+    }
+
+    .auth-progress {
+        margin-top: 1rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .auth-body {
+        padding: 1.5rem 1rem;
+    }
+
+    .auth-content {
+        padding: 2rem 1.5rem;
+    }
+
+    .auth-title {
+        font-size: 1.8rem;
+    }
 
     .auth-subtitle {
-        color: var(--text-secondary);
-        margin-bottom: 2rem;
+        font-size: 0.95rem;
     }
 
-    .auth-form {
-        display: grid;
-        gap: 1rem;
-        text-align: left;
+    .auth-showcase {
+        padding: 2rem 1.75rem;
+        gap: 1.5rem;
     }
 
-    .form-field {
-        display: flex;
+    .auth-progress {
         flex-direction: column;
-        gap: 0.5rem;
-    }
-
-    .form-field label {
-        font-weight: 600;
-        color: var(--text-primary);
-    }
-
-    .form-field input {
-        padding: 0.65rem;
-        border: 1px solid var(--border-color);
-        border-radius: var(--radius-md);
-    }
-
-    .field-error input {
-        border-color: var(--danger-color);
-    }
-
-    .field-error small {
-        color: var(--danger-color);
-    }
-
-    .auth-submit {
-        width: 100%;
-        justify-content: center;
-    }
-
-    .auth-alert {
-        padding: 0.75rem 1rem;
-        border-radius: var(--radius-md);
-        font-size: 0.9rem;
-    }
-
-    .auth-alert-success {
-        background: rgba(34, 197, 94, 0.15);
-        color: #15803d;
-    }
-
-    .auth-alert-danger {
-        background: rgba(239, 68, 68, 0.15);
-        color: #b91c1c;
-    }
-
-    .auth-footer {
-        margin-top: 1.5rem;
-        color: var(--text-secondary);
-    }
-
-    .auth-footer a {
-        color: var(--primary-color);
-        font-weight: 600;
-        text-decoration: none;
-    }
-
-    .error-meta {
-        margin: 1.5rem 0;
-        padding: 1rem;
-        background: var(--bg-secondary);
-        border: 1px solid var(--border-color);
-        border-radius: var(--radius-md);
-        line-height: 1.6;
-    }
-
-    .btn-back {
-        display: inline-block;
-        margin-top: 1rem;
-        padding: 0.6rem 1.2rem;
-        background-color: var(--primary-color);
-        color: #fff;
-        border-radius: var(--radius-md);
-        text-decoration: none;
-        font-weight: 600;
-        transition: background-color 0.2s ease;
-    }
-
-    .btn-back:hover {
-        background-color: #1d4ed8;
+        align-items: flex-start;
     }
 }

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -2,35 +2,65 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Đăng nhập hệ thống</title>
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body class="auth-body">
 <div th:replace="~{fragments/header :: popup}"></div>
-<div class="auth-container">
-    <h1>Đăng nhập</h1>
-    <p class="auth-subtitle">Quản lý ký túc xá Phenikaa</p>
 
-    <div th:if="${param.error}" class="auth-alert auth-alert-danger">
-        Tên đăng nhập hoặc mật khẩu không chính xác.
-    </div>
-    <div th:if="${param.logout}" class="auth-alert auth-alert-success">
-        Bạn đã đăng xuất khỏi hệ thống.
-    </div>
-
-    <form th:action="@{/login}" method="post" class="auth-form">
-        <div class="form-field">
-            <label for="username">Tên đăng nhập</label>
-            <input id="username" name="username" type="text" required placeholder="Nhập tên đăng nhập">
+<div class="auth-wrapper">
+    <div class="auth-card">
+        <div class="auth-showcase">
+            <div class="auth-brand">
+                <span class="auth-logo">KTX</span>
+                <div class="auth-brand-text">
+                    <h2>Phenikaa Dormitory</h2>
+                    <p>Hệ thống quản lý ký túc xá</p>
+                </div>
+            </div>
+            <p class="auth-description">
+                Theo dõi sinh viên, phòng ở và dịch vụ tiện ích trên một nền tảng duy nhất.
+            </p>
+            <ul class="auth-highlights">
+                <li>Điều phối phòng ở trực quan và khoa học</li>
+                <li>Kiểm soát phí dịch vụ minh bạch, kịp thời</li>
+                <li>Kết nối nhanh với sinh viên qua thông báo tức thì</li>
+            </ul>
+            <div class="auth-progress">
+                <span>98%</span>
+                <p>Mức độ hài lòng từ ban quản lý ký túc xá</p>
+            </div>
         </div>
-        <div class="form-field">
-            <label for="password">Mật khẩu</label>
-            <input id="password" name="password" type="password" required placeholder="Nhập mật khẩu">
-        </div>
-        <button class="button btn-add auth-submit" type="submit">Đăng nhập</button>
-    </form>
 
-    <p class="auth-footer">Chưa có tài khoản? <a th:href="@{/register}">Đăng ký ngay</a></p>
+        <div class="auth-content">
+            <h1 class="auth-title">Chào mừng trở lại!</h1>
+            <p class="auth-subtitle">Đăng nhập để tiếp tục quản lý ký túc xá Phenikaa.</p>
+
+            <div th:if="${param.error}" class="auth-alert auth-alert-danger">
+                Tên đăng nhập hoặc mật khẩu không chính xác.
+            </div>
+            <div th:if="${param.logout}" class="auth-alert auth-alert-success">
+                Bạn đã đăng xuất khỏi hệ thống.
+            </div>
+
+            <form th:action="@{/login}" method="post" class="auth-form">
+                <div class="form-field">
+                    <label for="username">Tên đăng nhập</label>
+                    <input id="username" name="username" type="text" required placeholder="Nhập tên đăng nhập">
+                </div>
+                <div class="form-field">
+                    <label for="password">Mật khẩu</label>
+                    <input id="password" name="password" type="password" required placeholder="Nhập mật khẩu">
+                </div>
+                <button class="button btn-add auth-submit" type="submit">Đăng nhập</button>
+            </form>
+
+            <p class="auth-footer">Chưa có tài khoản?
+                <a th:href="@{/register}">Đăng ký ngay</a>
+            </p>
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/auth/register.html
+++ b/src/main/resources/templates/auth/register.html
@@ -2,47 +2,75 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Đăng ký tài khoản sinh viên</title>
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body class="auth-body">
-<div class="auth-container">
-    <h1>Đăng ký</h1>
-    <p class="auth-subtitle">Liên kết tài khoản với hồ sơ sinh viên của bạn</p>
+<div class="auth-wrapper">
+    <div class="auth-card">
+        <div class="auth-showcase">
+            <div class="auth-brand">
+                <span class="auth-logo">KTX</span>
+                <div class="auth-brand-text">
+                    <h2>Phenikaa Dormitory</h2>
+                    <p>Hệ thống quản lý ký túc xá</p>
+                </div>
+            </div>
+            <p class="auth-description">
+                Liên kết tài khoản sinh viên để truy cập lịch sử ở, dịch vụ và thông báo từ ban quản lý.
+            </p>
+            <ul class="auth-highlights">
+                <li>Đồng bộ tài khoản với dữ liệu sinh viên đã xác thực</li>
+                <li>Theo dõi yêu cầu dịch vụ và phí tiện ích dễ dàng</li>
+                <li>Nhận thông báo quan trọng ngay khi có cập nhật</li>
+            </ul>
+            <div class="auth-progress">
+                <span>5'</span>
+                <p>Hoàn tất đăng ký và bắt đầu sử dụng ngay</p>
+            </div>
+        </div>
 
-    <form th:action="@{/register}" method="post" th:object="${registrationForm}" class="auth-form">
-        <div class="form-field" th:classappend="${#fields.hasErrors('studentCode')} ? ' field-error'">
-            <label for="studentCode">Mã sinh viên</label>
-            <input id="studentCode" th:field="*{studentCode}" required placeholder="VD: SV01">
-            <small th:if="${#fields.hasErrors('studentCode')}" th:errors="*{studentCode}"></small>
-        </div>
-        <div class="form-field" th:classappend="${#fields.hasErrors('email')} ? ' field-error'">
-            <label for="email">Email sinh viên</label>
-            <input id="email" th:field="*{email}" type="email" required placeholder="Email đã đăng ký với KTX">
-            <small th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></small>
-        </div>
-        <div class="form-field" th:classappend="${#fields.hasErrors('username')} ? ' field-error'">
-            <label for="username">Tên đăng nhập</label>
-            <input id="username" th:field="*{username}" required placeholder="Tối thiểu 4 ký tự">
-            <small th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></small>
-        </div>
-        <div class="form-field" th:classappend="${#fields.hasErrors('password')} ? ' field-error'">
-            <label for="password">Mật khẩu</label>
-            <input id="password" th:field="*{password}" type="password" required placeholder="Tối thiểu 6 ký tự">
-            <small th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></small>
-        </div>
-        <div class="form-field" th:classappend="${#fields.hasErrors('confirmPassword')} ? ' field-error'">
-            <label for="confirmPassword">Xác nhận mật khẩu</label>
-            <input id="confirmPassword" th:field="*{confirmPassword}" type="password" required placeholder="Nhập lại mật khẩu">
-            <small th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></small>
-        </div>
-        <div th:if="${#fields.hasGlobalErrors()}" class="auth-alert auth-alert-danger">
-            <span th:each="err : ${#fields.globalErrors()}" th:text="${err}"></span>
-        </div>
-        <button class="button btn-add auth-submit" type="submit">Đăng ký</button>
-    </form>
+        <div class="auth-content">
+            <h1 class="auth-title">Tạo tài khoản mới</h1>
+            <p class="auth-subtitle">Liên kết tài khoản với hồ sơ sinh viên của bạn để sử dụng các dịch vụ ký túc xá.</p>
 
-    <p class="auth-footer">Đã có tài khoản? <a th:href="@{/login}">Quay lại đăng nhập</a></p>
+            <form th:action="@{/register}" method="post" th:object="${registrationForm}" class="auth-form">
+                <div class="form-field" th:classappend="${#fields.hasErrors('studentCode')} ? ' field-error'">
+                    <label for="studentCode">Mã sinh viên</label>
+                    <input id="studentCode" th:field="*{studentCode}" required placeholder="VD: SV01">
+                    <small th:if="${#fields.hasErrors('studentCode')}" th:errors="*{studentCode}"></small>
+                </div>
+                <div class="form-field" th:classappend="${#fields.hasErrors('email')} ? ' field-error'">
+                    <label for="email">Email sinh viên</label>
+                    <input id="email" th:field="*{email}" type="email" required placeholder="Email đã đăng ký với KTX">
+                    <small th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></small>
+                </div>
+                <div class="form-field" th:classappend="${#fields.hasErrors('username')} ? ' field-error'">
+                    <label for="username">Tên đăng nhập</label>
+                    <input id="username" th:field="*{username}" required placeholder="Tối thiểu 4 ký tự">
+                    <small th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></small>
+                </div>
+                <div class="form-field" th:classappend="${#fields.hasErrors('password')} ? ' field-error'">
+                    <label for="password">Mật khẩu</label>
+                    <input id="password" th:field="*{password}" type="password" required placeholder="Tối thiểu 6 ký tự">
+                    <small th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></small>
+                </div>
+                <div class="form-field" th:classappend="${#fields.hasErrors('confirmPassword')} ? ' field-error'">
+                    <label for="confirmPassword">Xác nhận mật khẩu</label>
+                    <input id="confirmPassword" th:field="*{confirmPassword}" type="password" required placeholder="Nhập lại mật khẩu">
+                    <small th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></small>
+                </div>
+                <div th:if="${#fields.hasGlobalErrors()}" class="auth-alert auth-alert-danger">
+                    <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+                </div>
+                <button class="button btn-add auth-submit" type="submit">Đăng ký</button>
+            </form>
+
+            <p class="auth-note">* Đảm bảo thông tin trùng khớp với hồ sơ sinh viên được lưu tại KTX để kích hoạt tài khoản.</p>
+            <p class="auth-footer">Đã có tài khoản? <a th:href="@{/login}">Quay lại đăng nhập</a></p>
+        </div>
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the login page with a split-card layout, welcoming messaging, and improved contextual information
- refresh the registration page with matching visuals, guidance text, and clearer error presentation
- overhaul the authentication styles to add gradients, responsive behavior, and polished form interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd464368048324a124d3f0d1e5cbb3