### PR TITLE
feat: add admin user management

### DIFF
--- a/src/main/java/com/example/dorm/config/SecurityConfig.java
+++ b/src/main/java/com/example/dorm/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("/dashboard", "/dashboard/**").hasAnyRole("ADMIN", "STAFF")
                         .requestMatchers("/account/**").hasAnyRole("ADMIN", "STAFF")
                         .requestMatchers("/maintenance/**", "/violations/**").hasAnyRole("ADMIN", "STAFF")
-                        .requestMatchers("/students/**", "/rooms/**", "/contracts/**", "/fees/**").hasRole("ADMIN")
+                        .requestMatchers("/students/**", "/rooms/**", "/contracts/**", "/fees/**", "/users/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/src/main/java/com/example/dorm/controller/UserManagementController.java
+++ b/src/main/java/com/example/dorm/controller/UserManagementController.java
@@ -1,0 +1,130 @@
+package com.example.dorm.controller;
+
+import com.example.dorm.dto.UserForm;
+import com.example.dorm.model.Role;
+import com.example.dorm.model.RoleName;
+import com.example.dorm.model.User;
+import com.example.dorm.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/users")
+public class UserManagementController {
+
+    private final UserService userService;
+
+    public UserManagementController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public String listUsers(Model model) {
+        List<User> users = userService.findAllUsers();
+        List<Role> roles = userService.findAllRoles();
+
+        model.addAttribute("users", users);
+        model.addAttribute("allRoles", roles);
+        return "users/list";
+    }
+
+    @GetMapping("/new")
+    public String showCreateForm(Model model) {
+        if (!model.containsAttribute("userForm")) {
+            UserForm form = new UserForm();
+            form.setRole(RoleName.ROLE_STAFF);
+            model.addAttribute("userForm", form);
+        }
+        model.addAttribute("roles", Arrays.stream(RoleName.values())
+                .filter(roleName -> roleName != RoleName.ROLE_STUDENT)
+                .collect(Collectors.toList()));
+        return "users/form";
+    }
+
+    @PostMapping
+    public String createUser(@Valid @ModelAttribute("userForm") UserForm form,
+                             BindingResult bindingResult,
+                             RedirectAttributes redirectAttributes) {
+        validatePasswords(form, bindingResult);
+
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute("org.springframework.validation.BindingResult.userForm", bindingResult);
+            redirectAttributes.addFlashAttribute("userForm", form);
+            return "redirect:/users/new";
+        }
+
+        try {
+            userService.createUser(form.getUsername(), form.getEmail(), form.getPassword(), form.getRole());
+            redirectAttributes.addFlashAttribute("message", "Tạo tài khoản nhân sự thành công");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+            return "redirect:/users";
+        } catch (IllegalStateException ex) {
+            String message = ex.getMessage();
+            if (message != null && message.toLowerCase(Locale.ROOT).contains("email")) {
+                bindingResult.rejectValue("email", "user.email.exists", message);
+            } else {
+                bindingResult.rejectValue("username", "user.exists", message);
+            }
+        } catch (RuntimeException ex) {
+            bindingResult.reject("user.create.error", ex.getMessage());
+        }
+
+        redirectAttributes.addFlashAttribute("org.springframework.validation.BindingResult.userForm", bindingResult);
+        redirectAttributes.addFlashAttribute("userForm", form);
+        return "redirect:/users/new";
+    }
+
+    @PostMapping("/{id}/roles")
+    public String updateRoles(@PathVariable Long id,
+                              @RequestParam(value = "roles", required = false) List<String> roleNames,
+                              RedirectAttributes redirectAttributes) {
+        try {
+            Set<RoleName> selectedRoles = convertToRoleNames(roleNames);
+            userService.updateUserRoles(id, selectedRoles);
+            redirectAttributes.addFlashAttribute("message", "Cập nhật phân quyền thành công");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+        } catch (IllegalArgumentException ex) {
+            redirectAttributes.addFlashAttribute("message", ex.getMessage());
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+        }
+        return "redirect:/users";
+    }
+
+    private void validatePasswords(UserForm form, BindingResult bindingResult) {
+        if (!form.getPassword().equals(form.getConfirmPassword())) {
+            bindingResult.rejectValue("confirmPassword", "password.mismatch", "Mật khẩu xác nhận không khớp");
+        }
+    }
+
+    private Set<RoleName> convertToRoleNames(List<String> roleNames) {
+        if (roleNames == null || roleNames.isEmpty()) {
+            throw new IllegalArgumentException("Vui lòng chọn ít nhất một vai trò");
+        }
+
+        EnumSet<RoleName> roles = EnumSet.noneOf(RoleName.class);
+        for (String roleName : roleNames) {
+            try {
+                roles.add(RoleName.valueOf(roleName.toUpperCase(Locale.ROOT)));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Vai trò không hợp lệ: " + roleName);
+            }
+        }
+        return roles;
+    }
+}

--- a/src/main/java/com/example/dorm/dto/UserForm.java
+++ b/src/main/java/com/example/dorm/dto/UserForm.java
@@ -1,0 +1,68 @@
+package com.example.dorm.dto;
+
+import com.example.dorm.model.RoleName;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class UserForm {
+
+    @NotBlank(message = "Tên đăng nhập không được để trống")
+    @Size(min = 4, message = "Tên đăng nhập phải có ít nhất 4 ký tự")
+    private String username;
+
+    @NotBlank(message = "Email không được để trống")
+    @Email(message = "Email không hợp lệ")
+    private String email;
+
+    @NotBlank(message = "Mật khẩu không được để trống")
+    @Size(min = 6, message = "Mật khẩu phải có ít nhất 6 ký tự")
+    private String password;
+
+    @NotBlank(message = "Xác nhận mật khẩu không được để trống")
+    private String confirmPassword;
+
+    @NotNull(message = "Vui lòng chọn vai trò")
+    private RoleName role;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+
+    public RoleName getRole() {
+        return role;
+    }
+
+    public void setRole(RoleName role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/dorm/service/UserService.java
+++ b/src/main/java/com/example/dorm/service/UserService.java
@@ -8,9 +8,12 @@ import com.example.dorm.repository.RoleRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class UserService {
@@ -55,6 +58,20 @@ public class UserService {
         return userRepository.findByUsername(username);
     }
 
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    public List<User> findAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public List<Role> findAllRoles() {
+        return roleRepository.findAll().stream()
+                .sorted(Comparator.comparing(role -> role.getName().name()))
+                .collect(Collectors.toList());
+    }
+
     public boolean hasRole(User user, RoleName roleName) {
         return user.getRoles().stream()
                 .anyMatch(role -> role.getName() == roleName);
@@ -94,5 +111,22 @@ public class UserService {
 
     public void deleteUser(Long id) {
         userRepository.deleteById(id);
+    }
+
+    public void updateUserRoles(Long id, Set<RoleName> roleNames) {
+        if (roleNames == null || roleNames.isEmpty()) {
+            throw new IllegalArgumentException("Người dùng phải có ít nhất một vai trò");
+        }
+
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User không tìm thấy"));
+
+        Set<Role> roles = roleNames.stream()
+                .map(roleName -> roleRepository.findByName(roleName)
+                        .orElseThrow(() -> new IllegalArgumentException("Role không tìm thấy: " + roleName)))
+                .collect(Collectors.toSet());
+
+        user.setRoles(roles);
+        userRepository.save(user);
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -418,6 +418,13 @@ h2 {
     margin-bottom: 1.5rem;
 }
 
+.form-subtitle {
+    text-align: center;
+    color: var(--text-secondary);
+    margin-top: -0.75rem;
+    margin-bottom: 1.5rem;
+}
+
 .alert {
     padding: 0.75rem 1rem;
     border-radius: var(--radius-md);
@@ -429,6 +436,18 @@ h2 {
 
 .alert.alert-danger {
     border-color: var(--danger-color);
+}
+
+.alert.alert-info {
+    background: rgba(59,130,246,0.08);
+    color: #1d4ed8;
+    border-color: rgba(59,130,246,0.3);
+}
+
+.alert.alert-success {
+    background: rgba(34,197,94,0.08);
+    color: #15803d;
+    border-color: rgba(34,197,94,0.3);
 }
 
 .form-group {
@@ -452,6 +471,35 @@ h2 {
     border-radius: var(--radius-sm);
 }
 
+.form-group.has-error label {
+    color: var(--danger-color);
+}
+
+.form-group.has-error input,
+.form-group.has-error select {
+    border-color: var(--danger-color);
+    box-shadow: 0 0 0 1px rgba(239,68,68,0.2);
+}
+
+.form-group .error {
+    display: block;
+    margin-left: 120px;
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    color: var(--danger-color);
+}
+
+.form-group-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin: 0.5rem 0 1rem 0;
+}
+
+.form-group-grid .form-group {
+    margin: 0;
+}
+
 .form-actions {
     text-align: center;
     margin-top: 1rem;
@@ -459,6 +507,48 @@ h2 {
 
 .form-actions .button {
     margin-right: 0.5rem;
+}
+
+.role-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.role-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(30,136,229,0.08);
+    color: var(--info-color);
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.roles-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.role-checkbox-group {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.role-checkbox-group label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.role-checkbox-group input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
 }
 
 .info-table {

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -34,6 +34,10 @@
                     <i class="fas fa-money-bill-wave"></i>
                     <span>Phí & thanh toán</span>
                 </a>
+                <a th:href="@{/users}" class="sidebar-link">
+                    <i class="fas fa-user-shield"></i>
+                    <span>Tài khoản & phân quyền</span>
+                </a>
             </nav>
         </div>
 

--- a/src/main/resources/templates/users/form.html
+++ b/src/main/resources/templates/users/form.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Tạo tài khoản nhân sự</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="fragments/sidebar :: sidebar"></div>
+<div class="content-with-sidebar">
+    <div class="form-container">
+        <h2>Tạo tài khoản nhân sự</h2>
+        <p class="form-subtitle">Sử dụng biểu mẫu này để thêm tài khoản cho quản trị viên hoặc nhân viên hỗ trợ.</p>
+
+        <div th:if="${message}" class="alert" th:classappend="${alertClass != null} ? ' ' + alertClass : ' alert-info'">
+            <p th:text="${message}"></p>
+        </div>
+
+        <form th:action="@{/users}" th:object="${userForm}" method="post">
+            <div class="form-group" th:classappend="${#fields.hasErrors('username')} ? ' has-error'">
+                <label for="username">Tên đăng nhập</label>
+                <input type="text" id="username" th:field="*{username}" placeholder="Ví dụ: admin01">
+                <small class="error" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></small>
+            </div>
+
+            <div class="form-group" th:classappend="${#fields.hasErrors('email')} ? ' has-error'">
+                <label for="email">Email</label>
+                <input type="email" id="email" th:field="*{email}" placeholder="name@phenikaa-uni.edu.vn">
+                <small class="error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></small>
+            </div>
+
+            <div class="form-group-grid">
+                <div class="form-group" th:classappend="${#fields.hasErrors('password')} ? ' has-error'">
+                    <label for="password">Mật khẩu</label>
+                    <input type="password" id="password" th:field="*{password}" placeholder="Tối thiểu 6 ký tự">
+                    <small class="error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></small>
+                </div>
+                <div class="form-group" th:classappend="${#fields.hasErrors('confirmPassword')} ? ' has-error'">
+                    <label for="confirmPassword">Xác nhận mật khẩu</label>
+                    <input type="password" id="confirmPassword" th:field="*{confirmPassword}" placeholder="Nhập lại mật khẩu">
+                    <small class="error" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></small>
+                </div>
+            </div>
+
+            <div class="form-group" th:classappend="${#fields.hasErrors('role')} ? ' has-error'">
+                <label for="role">Vai trò</label>
+                <select id="role" th:field="*{role}">
+                    <option th:each="role : ${roles}"
+                            th:value="${role}"
+                            th:text="${role.displayName}"></option>
+                </select>
+                <small class="error" th:if="${#fields.hasErrors('role')}" th:errors="*{role}"></small>
+            </div>
+
+            <div th:if="${#fields.hasGlobalErrors()}" class="alert alert-danger">
+                <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+            </div>
+
+            <div class="form-actions">
+                <button type="submit" class="button btn-add">
+                    <i class="fas fa-save"></i>
+                    <span>Lưu tài khoản</span>
+                </button>
+                <a th:href="@{/users}" class="button btn-cancel">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/users/list.html
+++ b/src/main/resources/templates/users/list.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <title>Quản lý tài khoản</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="fragments/sidebar :: sidebar"></div>
+<div class="content-with-sidebar">
+    <div class="container">
+        <div class="page-header">
+            <div>
+                <h1>Quản lý tài khoản</h1>
+                <p class="page-subtitle">Thêm nhân sự và phân quyền truy cập hệ thống</p>
+            </div>
+            <a th:href="@{/users/new}" class="button btn-add">
+                <i class="fas fa-user-plus"></i>
+                <span>Thêm tài khoản</span>
+            </a>
+        </div>
+
+        <div th:if="${message}" class="alert" th:classappend="${alertClass != null} ? ' ' + alertClass : ' alert-info'">
+            <p th:text="${message}"></p>
+        </div>
+
+        <h2>Danh sách người dùng</h2>
+        <div class="responsive-table">
+            <table>
+                <thead>
+                <tr>
+                    <th>Tên đăng nhập</th>
+                    <th>Email</th>
+                    <th>Trạng thái</th>
+                    <th>Vai trò</th>
+                    <th class="actions-column">Thao tác</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:if="${#lists.isEmpty(users)}">
+                    <td colspan="5" class="no-data">Chưa có tài khoản nào được tạo.</td>
+                </tr>
+                <tr th:each="user : ${users}">
+                    <td>
+                        <span class="table-primary" th:text="${user.username}"></span>
+                    </td>
+                    <td th:text="${user.email}"></td>
+                    <td>
+                        <span class="badge" th:text="${user.enabled ? 'Hoạt động' : 'Bị khóa'}"
+                              th:classappend="${user.enabled} ? ' badge-success' : ' badge-danger'"></span>
+                    </td>
+                    <td>
+                        <div class="role-list">
+                            <span th:each="role : ${user.roles}"
+                                  class="role-chip"
+                                  th:text="${role.description != null ? role.description : role.name.displayName}"></span>
+                        </div>
+                    </td>
+                    <td>
+                        <form th:action="@{/users/{id}/roles(id=${user.id})}" method="post" class="inline-form roles-form">
+                            <div class="role-checkbox-group">
+                                <label th:each="role : ${allRoles}">
+                                    <input type="checkbox" name="roles"
+                                           th:value="${role.name}"
+                                           th:checked="${!#lists.isEmpty(user.roles.?[name == role.name])}">
+                                    <span th:text="${role.description != null ? role.description : role.name.displayName}"></span>
+                                </label>
+                            </div>
+                            <button type="submit" class="button btn-edit">
+                                <i class="fas fa-save"></i>
+                                <span>Cập nhật</span>
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a user management controller and DTO so admins can create staff accounts and adjust role assignments
- expose user and role lookup helpers plus role update logic in the service layer and secure the new routes for admins
- provide Thymeleaf pages and styling updates for managing accounts and link the section from the sidebar

## Testing
- mvn -q -DskipTests package *(fails: unable to download Spring Boot parent POM – Maven Central returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da89a9f55483268b0c273a21860fbc