### PR TITLE
Add profile self-service for all user roles

### DIFF
--- a/src/main/java/com/example/dorm/config/SecurityConfig.java
+++ b/src/main/java/com/example/dorm/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/login", "/register", "/css/**", "/js/**", "/images/**", "/h2-console/**").permitAll()
                         .requestMatchers("/student/**").hasRole("STUDENT")
                         .requestMatchers("/dashboard", "/dashboard/**").hasAnyRole("ADMIN", "STAFF")
-                        .requestMatchers("/account/**").hasAnyRole("ADMIN", "STAFF")
+                        .requestMatchers("/account/**").hasAnyRole("ADMIN", "STAFF", "STUDENT")
                         .requestMatchers("/maintenance/**", "/violations/**").hasAnyRole("ADMIN", "STAFF")
                         .requestMatchers("/students/**", "/rooms/**", "/contracts/**", "/fees/**", "/users/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/example/dorm/controller/AccountController.java
+++ b/src/main/java/com/example/dorm/controller/AccountController.java
@@ -1,7 +1,11 @@
 package com.example.dorm.controller;
 
 import com.example.dorm.dto.ChangePasswordForm;
+import com.example.dorm.dto.ProfileForm;
+import com.example.dorm.model.RoleName;
+import com.example.dorm.model.Student;
 import com.example.dorm.model.User;
+import com.example.dorm.service.StudentService;
 import com.example.dorm.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.security.core.Authentication;
@@ -13,15 +17,20 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Locale;
 
 @Controller
 @RequestMapping("/account")
 public class AccountController {
 
     private final UserService userService;
+    private final StudentService studentService;
 
-    public AccountController(UserService userService) {
+    public AccountController(UserService userService, StudentService studentService) {
         this.userService = userService;
+        this.studentService = studentService;
     }
 
     @GetMapping("/password")
@@ -30,6 +39,15 @@ public class AccountController {
             model.addAttribute("changePasswordForm", new ChangePasswordForm());
         }
         return "auth/change-password";
+    }
+
+    @GetMapping("/profile")
+    public String showProfile(Model model, Authentication authentication) {
+        User user = getAuthenticatedUser(authentication);
+        boolean isStudent = userService.hasRole(user, RoleName.ROLE_STUDENT);
+
+        prepareProfileModel(model, user, isStudent);
+        return "account/profile";
     }
 
     @PostMapping("/password")
@@ -74,6 +92,82 @@ public class AccountController {
         } catch (Exception ex) {
             bindingResult.reject("password.change.error", ex.getMessage());
             return "auth/change-password";
+        }
+    }
+
+    @PostMapping("/profile")
+    @Transactional
+    public String updateProfile(@Valid @ModelAttribute("profileForm") ProfileForm form,
+                                BindingResult bindingResult,
+                                Authentication authentication,
+                                Model model,
+                                RedirectAttributes redirectAttributes) {
+        User user = getAuthenticatedUser(authentication);
+        boolean isStudent = userService.hasRole(user, RoleName.ROLE_STUDENT);
+
+        if (bindingResult.hasErrors()) {
+            prepareProfileModel(model, user, isStudent);
+            return "account/profile";
+        }
+
+        try {
+            if (isStudent) {
+                Student student = studentService.findByUsername(user.getUsername())
+                        .orElseThrow(() -> new IllegalStateException("Không tìm thấy thông tin sinh viên"));
+                studentService.updateContactInfo(student.getId(), form.getPhone(), form.getEmail(), form.getAddress());
+            }
+            userService.updateProfile(user, form.getEmail(), form.getFullName(), form.getPhone());
+
+            redirectAttributes.addFlashAttribute("message", "Cập nhật thông tin cá nhân thành công");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+            return "redirect:/account/profile";
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            String message = ex.getMessage() != null ? ex.getMessage() : "Không thể cập nhật thông tin";
+            if (message.toLowerCase(Locale.ROOT).contains("email")) {
+                bindingResult.rejectValue("email", "profile.email", message);
+            } else {
+                bindingResult.reject("profile.update.error", message);
+            }
+            prepareProfileModel(model, user, isStudent);
+            return "account/profile";
+        }
+    }
+
+    private User getAuthenticatedUser(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new IllegalStateException("Phiên đăng nhập không hợp lệ. Vui lòng đăng nhập lại.");
+        }
+        return userService.findByUsername(authentication.getName())
+                .orElseThrow(() -> new IllegalStateException("Không tìm thấy thông tin người dùng"));
+    }
+
+    private void prepareProfileModel(Model model, User user, boolean isStudent) {
+        Student student = null;
+        if (isStudent) {
+            student = studentService.findByUsername(user.getUsername())
+                    .orElseThrow(() -> new IllegalStateException("Không tìm thấy thông tin sinh viên"));
+        }
+
+        if (!model.containsAttribute("profileForm")) {
+            ProfileForm form = new ProfileForm();
+            form.setUsername(user.getUsername());
+            form.setFullName(user.getFullName());
+            String preferredEmail = user.getEmail();
+            if (student != null && student.getEmail() != null && !student.getEmail().isBlank()) {
+                preferredEmail = student.getEmail();
+            }
+            form.setEmail(preferredEmail);
+            form.setPhone(student != null && student.getPhone() != null ? student.getPhone() : user.getPhone());
+            if (student != null) {
+                form.setAddress(student.getAddress());
+            }
+            model.addAttribute("profileForm", form);
+        }
+
+        model.addAttribute("isStudent", isStudent);
+        model.addAttribute("canEditFullName", !isStudent);
+        if (student != null) {
+            model.addAttribute("studentProfile", student);
         }
     }
 }

--- a/src/main/java/com/example/dorm/dto/ProfileForm.java
+++ b/src/main/java/com/example/dorm/dto/ProfileForm.java
@@ -1,0 +1,63 @@
+package com.example.dorm.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class ProfileForm {
+
+    private String username;
+
+    @Size(max = 100, message = "Họ tên không được vượt quá 100 ký tự")
+    private String fullName;
+
+    @NotBlank(message = "Email không được để trống")
+    @Email(message = "Email không hợp lệ")
+    private String email;
+
+    @Size(max = 20, message = "Số điện thoại không được vượt quá 20 ký tự")
+    private String phone;
+
+    @Size(max = 255, message = "Địa chỉ không được vượt quá 255 ký tự")
+    private String address;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}

--- a/src/main/java/com/example/dorm/model/User.java
+++ b/src/main/java/com/example/dorm/model/User.java
@@ -17,6 +17,10 @@ public class User {
 
     private String email;
 
+    private String fullName;
+
+    private String phone;
+
     private boolean enabled = true;
 
     @ManyToMany(fetch = FetchType.EAGER)
@@ -40,6 +44,10 @@ public class User {
     public void setPassword(String password) { this.password = password; }
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
+    public String getFullName() { return fullName; }
+    public void setFullName(String fullName) { this.fullName = fullName; }
+    public String getPhone() { return phone; }
+    public void setPhone(String phone) { this.phone = phone; }
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
     public Set<Role> getRoles() { return roles; }

--- a/src/main/java/com/example/dorm/service/StudentService.java
+++ b/src/main/java/com/example/dorm/service/StudentService.java
@@ -78,6 +78,22 @@ public class StudentService {
         return studentRepository.count();
     }
 
+    public Student updateContactInfo(Long studentId, String phone, String email, String address) {
+        Student student = getRequiredStudent(studentId);
+
+        if (email != null && !email.isBlank()) {
+            student.setEmail(email.trim());
+        } else {
+            student.setEmail(null);
+        }
+        student.setPhone(phone != null && !phone.isBlank() ? phone.trim() : null);
+        student.setAddress(address != null && !address.isBlank() ? address.trim() : null);
+
+        validateUniqueEmail(student);
+
+        return studentRepository.save(student);
+    }
+
     private void validateUniqueCode(Student student) {
         if (student.getCode() == null || student.getCode().isBlank()) {
             return;

--- a/src/main/java/com/example/dorm/service/UserService.java
+++ b/src/main/java/com/example/dorm/service/UserService.java
@@ -101,10 +101,34 @@ public class UserService {
 
         user.setEmail(userDetails.getEmail());
         user.setEnabled(userDetails.isEnabled());
+        user.setFullName(userDetails.getFullName());
+        user.setPhone(userDetails.getPhone());
 
         if (userDetails.getPassword() != null && !userDetails.getPassword().isEmpty()) {
             user.setPassword(passwordEncoder.encode(userDetails.getPassword()));
         }
+
+        return userRepository.save(user);
+    }
+
+    public User updateProfile(User user, String email, String fullName, String phone) {
+        if (user == null) {
+            throw new IllegalArgumentException("Không tìm thấy người dùng");
+        }
+
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Email không được để trống");
+        }
+
+        userRepository.findByEmail(email)
+                .filter(existing -> !existing.getId().equals(user.getId()))
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("Email đã được sử dụng bởi tài khoản khác");
+                });
+
+        user.setEmail(email.trim());
+        user.setFullName(fullName != null && !fullName.isBlank() ? fullName.trim() : null);
+        user.setPhone(phone != null && !phone.isBlank() ? phone.trim() : null);
 
         return userRepository.save(user);
     }

--- a/src/main/resources/templates/account/profile.html
+++ b/src/main/resources/templates/account/profile.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Cập nhật thông tin cá nhân</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="~{fragments/header :: popup}"></div>
+
+<div th:if="${isStudent}" class="student-layout">
+    <div th:replace="fragments/student-sidebar :: studentSidebar"></div>
+    <div class="student-content">
+        <div class="student-page-header">
+            <div>
+                <h1>Cập nhật thông tin</h1>
+                <p class="text-muted">Điều chỉnh thông tin liên hệ để ban quản lý dễ dàng hỗ trợ bạn</p>
+            </div>
+        </div>
+        <div th:replace="~{::profileForm}"></div>
+        <div class="profile-grid" th:if="${studentProfile != null}">
+            <div class="profile-card">
+                <h3><i class="fas fa-user-graduate"></i> Thông tin sinh viên</h3>
+                <p><strong>Mã sinh viên:</strong> <span th:text="${studentProfile.code}"></span></p>
+                <p><strong>Họ tên:</strong> <span th:text="${studentProfile.name}"></span></p>
+                <p><strong>Khoa:</strong> <span th:text="${studentProfile.department}"></span></p>
+                <p><strong>Năm học:</strong> <span th:text="${studentProfile.studyYear}"></span></p>
+            </div>
+            <div class="profile-card">
+                <h3><i class="fas fa-bed"></i> Thông tin phòng</h3>
+                <p><strong>Phòng hiện tại:</strong>
+                    <span th:text="${studentProfile.room != null ? studentProfile.room.number : 'Chưa có'}"></span>
+                </p>
+                <p><strong>Giới tính:</strong> <span th:text="${studentProfile.gender}"></span></p>
+                <p><strong>Ngày sinh:</strong> <span th:text="${studentProfile.dob}"></span></p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div th:if="${!isStudent}">
+    <div th:replace="fragments/sidebar :: sidebar"></div>
+    <div class="content-with-sidebar">
+        <div th:replace="~{::profileForm}"></div>
+    </div>
+</div>
+
+<th:block th:fragment="profileForm">
+    <div class="form-container">
+        <h2>Thông tin cá nhân</h2>
+        <p class="text-muted">Cập nhật email và thông tin liên hệ để nhận thông báo chính xác.</p>
+
+        <div class="alert alert-danger" th:if="${#fields.hasGlobalErrors()}">
+            <span th:each="err : ${#fields.globalErrors()}" th:text="${err}"></span>
+        </div>
+
+        <form th:action="@{/account/profile}" th:object="${profileForm}" method="post" class="form-grid">
+            <div class="form-group">
+                <label for="username">Tên đăng nhập</label>
+                <input id="username" type="text" th:field="*{username}" readonly>
+            </div>
+
+            <div class="form-group" th:if="${canEditFullName}">
+                <label for="fullName">Họ tên hiển thị</label>
+                <input id="fullName" type="text" th:field="*{fullName}" placeholder="Nhập họ tên để hiển thị">
+                <span class="error" th:if="${#fields.hasErrors('fullName')}" th:errors="*{fullName}"></span>
+            </div>
+
+            <div class="form-group" th:if="${!canEditFullName}">
+                <label>Họ tên</label>
+                <input type="text" th:value="${studentProfile != null ? studentProfile.name : profileForm.fullName}" readonly>
+                <input type="hidden" th:field="*{fullName}">
+            </div>
+
+            <div class="form-group">
+                <label for="email">Email liên hệ</label>
+                <input id="email" type="email" th:field="*{email}" placeholder="example@domain.com">
+                <span class="error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></span>
+            </div>
+
+            <div class="form-group">
+                <label for="phone">Số điện thoại</label>
+                <input id="phone" type="text" th:field="*{phone}" placeholder="09xxxxxxxx">
+                <span class="error" th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}"></span>
+            </div>
+
+            <div class="form-group" th:if="${isStudent}">
+                <label for="address">Địa chỉ liên hệ</label>
+                <input id="address" type="text" th:field="*{address}" placeholder="Địa chỉ cư trú hiện tại">
+                <span class="error" th:if="${#fields.hasErrors('address')}" th:errors="*{address}"></span>
+            </div>
+            <input type="hidden" th:if="${!isStudent}" th:field="*{address}">
+
+            <div class="form-actions">
+                <button type="submit" class="button btn-save"><i class="fas fa-save"></i> Lưu thay đổi</button>
+                <a th:href="${isStudent} ? @{/student/profile} : @{/dashboard}" class="button btn-cancel">
+                    <i class="fas fa-arrow-left"></i> Quay lại
+                </a>
+            </div>
+        </form>
+    </div>
+</th:block>
+
+</body>
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -23,7 +23,10 @@
                     <span th:text="${#strings.arrayJoin(auth.authorities.![authority], ', ')}"></span>
                 </div>
                 <div class="user-actions">
-                    <a class="change-password-link" th:href="@{/account/password}" sec:authorize="hasAnyRole('ADMIN','STAFF')">
+                    <a class="change-password-link" th:href="@{/account/profile}" sec:authorize="isAuthenticated()">
+                        Cập nhật thông tin
+                    </a>
+                    <a class="change-password-link" th:href="@{/account/password}" sec:authorize="hasAnyRole('ADMIN','STAFF','STUDENT')">
                         Đổi mật khẩu
                     </a>
                     <form th:action="@{/logout}" method="post" class="logout-form">

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -59,6 +59,10 @@
         <div class="sidebar-section">
             <h3 class="sidebar-title">Khác</h3>
             <nav class="sidebar-nav">
+                <a th:href="@{/account/profile}" class="sidebar-link" sec:authorize="isAuthenticated()">
+                    <i class="fas fa-user-cog"></i>
+                    <span>Thông tin cá nhân</span>
+                </a>
                 <a href="javascript:void(0)" class="sidebar-link special" id="aboutBtn">
                     <i class="fas fa-info-circle"></i>
                     <span>Giới thiệu</span>

--- a/src/main/resources/templates/fragments/student-sidebar.html
+++ b/src/main/resources/templates/fragments/student-sidebar.html
@@ -8,6 +8,9 @@
             <a th:href="@{/student/profile}" class="student-nav-link">
                 <i class="fas fa-id-card"></i><span>Hồ sơ cá nhân</span>
             </a>
+            <a th:href="@{/account/profile}" class="student-nav-link">
+                <i class="fas fa-user-edit"></i><span>Cập nhật thông tin</span>
+            </a>
             <a th:href="@{/student/contracts}" class="student-nav-link">
                 <i class="fas fa-file-contract"></i><span>Hợp đồng</span>
             </a>

--- a/src/main/resources/templates/student/profile.html
+++ b/src/main/resources/templates/student/profile.html
@@ -17,6 +17,11 @@
                 <h1>Thông tin cá nhân</h1>
                 <p class="text-muted">Kiểm tra và cập nhật thông tin liên hệ của bạn</p>
             </div>
+            <div>
+                <a class="button btn-save" th:href="@{/account/profile}">
+                    <i class="fas fa-user-edit"></i> Cập nhật thông tin
+                </a>
+            </div>
         </div>
 
         <div class="profile-grid">


### PR DESCRIPTION
## Summary
- add a shared account profile page that lets authenticated users update their contact information
- extend user and student services/entities to store phone and display name data and keep student contact details in sync
- refresh navigation/header links so admins, staff, and students can quickly reach the new profile management screen

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download Spring Boot parent POM from Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da918a5abc83268451afa1a0120559