### PR TITLE
Refine profile update interface and header user menu

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -91,6 +91,10 @@ body {
     gap: 1rem;
 }
 .user-profile {
+    position: relative;
+}
+
+.user-trigger {
     display: flex;
     align-items: center;
     gap: 0.75rem;
@@ -99,7 +103,21 @@ body {
     border: 1px solid var(--border-color);
     border-radius: var(--radius-lg);
     cursor: pointer;
+    font: inherit;
+    color: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
+
+.user-trigger:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.user-profile.open .user-trigger {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
 .user-avatar {
     width: 2rem;
     height: 2rem;
@@ -111,6 +129,74 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
+}
+
+.user-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.1;
+}
+
+.user-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.user-role {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.user-caret {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.user-dropdown {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    min-width: 14rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    padding: 0.5rem 0;
+    display: flex;
+    flex-direction: column;
+    z-index: 1100;
+}
+
+.user-dropdown-link {
+    width: 100%;
+    padding: 0.65rem 1rem;
+    background: transparent;
+    border: none;
+    text-align: left;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    text-decoration: none;
+    display: block;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.user-dropdown-link:hover,
+.user-dropdown-link:focus {
+    background: rgba(59, 130, 246, 0.1);
+    color: var(--primary-dark);
+}
+
+.user-dropdown form {
+    margin: 0;
+}
+
+.user-dropdown-logout {
+    width: 100%;
+    cursor: pointer;
 }
 
 /* ======== SIDEBAR ======== */
@@ -1019,19 +1105,6 @@ h2 {
     gap: 0.75rem;
 }
 
-.logout-form {
-    margin: 0;
-}
-
-.logout-btn {
-    background: var(--danger-color);
-    color: white;
-    border: none;
-    border-radius: var(--radius-md);
-    padding: 0.4rem 0.75rem;
-    cursor: pointer;
-}
-
 .login-link {
     display: inline-flex;
     align-items: center;
@@ -1046,39 +1119,6 @@ h2 {
 .login-link:hover {
     background: var(--primary-color);
     color: white;
-}
-
-.user-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
-}
-
-.user-name {
-    font-weight: 600;
-}
-
-.user-role {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-    text-transform: uppercase;
-}
-
-.user-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-left: 0.5rem;
-}
-
-.change-password-link {
-    color: var(--primary-color);
-    text-decoration: none;
-    font-weight: 600;
-}
-
-.change-password-link:hover {
-    text-decoration: underline;
 }
 
 .profile-grid {
@@ -1100,6 +1140,181 @@ h2 {
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.75rem;
+}
+
+.profile-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin: 0 auto;
+    max-width: 960px;
+}
+
+.profile-card.profile-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1.75rem;
+    flex-wrap: wrap;
+}
+
+.profile-card-main {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.profile-avatar-large {
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--primary-color), var(--info-color));
+    color: #fff;
+    font-weight: 700;
+    font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.profile-card-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.profile-name {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.profile-subtitle {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.profile-card-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+    min-width: 160px;
+}
+
+.profile-meta-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    letter-spacing: 0.08em;
+}
+
+.profile-meta-value {
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+    word-break: break-word;
+}
+
+.profile-form {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.form-alert {
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    font-weight: 500;
+}
+
+.form-alert-error {
+    background: rgba(239, 68, 68, 0.08);
+    border-color: rgba(239, 68, 68, 0.3);
+    color: var(--danger-color);
+}
+
+.profile-form-grid {
+    gap: 1.25rem 1.5rem;
+}
+
+.input-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.input-field label {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.input-field input,
+.input-field select,
+.input-field textarea {
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-field input:focus,
+.input-field select:focus,
+.input-field textarea:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+    outline: none;
+}
+
+.input-field.has-error label {
+    color: var(--danger-color);
+}
+
+.input-field.has-error input,
+.input-field.has-error select,
+.input-field.has-error textarea {
+    border-color: var(--danger-color);
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+}
+
+.input-field .error {
+    font-size: 0.85rem;
+    color: var(--danger-color);
+}
+
+.profile-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.profile-actions .button {
+    min-width: 160px;
+}
+
+.profile-actions .btn-cancel {
+    background: rgba(148, 163, 184, 0.15);
+    color: var(--text-secondary);
+}
+
+.profile-actions .btn-cancel:hover {
+    color: var(--text-primary);
+}
+
+.profile-actions .btn-save {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .contract-grid {
@@ -1501,5 +1716,23 @@ h2 {
     .auth-progress {
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    .profile-card.profile-summary {
+        padding: 1.5rem;
+        align-items: flex-start;
+    }
+
+    .profile-card-meta {
+        align-items: flex-start;
+    }
+
+    .profile-actions {
+        flex-direction: column-reverse;
+        align-items: stretch;
+    }
+
+    .profile-actions .button {
+        width: 100%;
     }
 }

--- a/src/main/resources/templates/account/profile.html
+++ b/src/main/resources/templates/account/profile.html
@@ -32,55 +32,64 @@
 </div>
 
 <th:block th:fragment="profileForm">
-    <div class="form-container">
-        <h2>Thông tin cá nhân</h2>
-        <p class="text-muted">Cập nhật email và thông tin liên hệ để nhận thông báo chính xác.</p>
+    <div class="profile-page" th:with="displayName=${studentProfile != null && studentProfile.name != null && !#strings.isEmpty(studentProfile.name) ? studentProfile.name : (!#strings.isEmpty(profileForm.fullName) ? profileForm.fullName : profileForm.username)}">
+        <section class="profile-card profile-summary">
+            <div class="profile-card-main">
+                <div class="profile-avatar-large" th:text="${displayName != null && displayName.length() > 0 ? displayName.substring(0,1).toUpperCase() : 'U'}">U</div>
+                <div class="profile-card-text">
+                    <h2 class="profile-name" th:text="${displayName}">Người dùng</h2>
+                    <p class="profile-subtitle" th:text="${isStudent} ? 'Sinh viên ký túc xá Phenikaa' : 'Thành viên hệ thống quản lý'}">Sinh viên ký túc xá Phenikaa</p>
+                </div>
+            </div>
+            <div class="profile-card-meta">
+                <span class="profile-meta-label">Tên đăng nhập</span>
+                <span class="profile-meta-value" th:text="${profileForm.username}">username</span>
+            </div>
+        </section>
 
-        <form th:action="@{/account/profile}" th:object="${profileForm}" method="post" class="form-grid">
-            <div class="alert alert-danger" th:if="${#fields.hasGlobalErrors()}">
+        <form th:action="@{/account/profile}" th:object="${profileForm}" method="post" class="profile-form">
+            <div class="form-alert form-alert-error" th:if="${#fields.hasGlobalErrors()}">
                 <span th:each="err : ${#fields.globalErrors()}" th:text="${err}"></span>
             </div>
-            <div class="form-group">
-                <label for="username">Tên đăng nhập</label>
-                <input id="username" type="text" th:field="*{username}" readonly>
-            </div>
 
-            <div class="form-group" th:if="${canEditFullName}">
-                <label for="fullName">Họ tên hiển thị</label>
-                <input id="fullName" type="text" th:field="*{fullName}" placeholder="Nhập họ tên để hiển thị">
-                <span class="error" th:if="${#fields.hasErrors('fullName')}" th:errors="*{fullName}"></span>
-            </div>
+            <div class="profile-grid profile-form-grid">
+                <div class="input-field" th:classappend="${#fields.hasErrors('fullName')} ? ' has-error'" th:if="${canEditFullName}">
+                    <label for="fullName">Họ tên hiển thị</label>
+                    <input id="fullName" type="text" th:field="*{fullName}" placeholder="Nhập họ tên để hiển thị">
+                    <span class="error" th:if="${#fields.hasErrors('fullName')}" th:errors="*{fullName}"></span>
+                </div>
 
-            <div class="form-group" th:if="${!canEditFullName}">
-                <label>Họ tên</label>
-                <input type="text" th:value="${studentProfile != null ? studentProfile.name : profileForm.fullName}" readonly>
-                <input type="hidden" th:field="*{fullName}">
-            </div>
+                <div class="input-field" th:if="${!canEditFullName}">
+                    <label>Họ tên</label>
+                    <input type="text" th:value="${studentProfile != null ? studentProfile.name : profileForm.fullName}" readonly>
+                    <input type="hidden" th:field="*{fullName}">
+                </div>
 
-            <div class="form-group">
-                <label for="email">Email liên hệ</label>
-                <input id="email" type="email" th:field="*{email}" placeholder="example@domain.com">
-                <span class="error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></span>
-            </div>
+                <div class="input-field" th:classappend="${#fields.hasErrors('email')} ? ' has-error'">
+                    <label for="email">Email liên hệ</label>
+                    <input id="email" type="email" th:field="*{email}" placeholder="example@domain.com">
+                    <span class="error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></span>
+                </div>
 
-            <div class="form-group">
-                <label for="phone">Số điện thoại</label>
-                <input id="phone" type="text" th:field="*{phone}" placeholder="09xxxxxxxx">
-                <span class="error" th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}"></span>
-            </div>
+                <div class="input-field" th:classappend="${#fields.hasErrors('phone')} ? ' has-error'">
+                    <label for="phone">Số điện thoại</label>
+                    <input id="phone" type="text" th:field="*{phone}" placeholder="09xxxxxxxx">
+                    <span class="error" th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}"></span>
+                </div>
 
-            <div class="form-group" th:if="${isStudent}">
-                <label for="address">Địa chỉ liên hệ</label>
-                <input id="address" type="text" th:field="*{address}" placeholder="Địa chỉ cư trú hiện tại">
-                <span class="error" th:if="${#fields.hasErrors('address')}" th:errors="*{address}"></span>
+                <div class="input-field" th:if="${isStudent}" th:classappend="${#fields.hasErrors('address')} ? ' has-error'">
+                    <label for="address">Địa chỉ liên hệ</label>
+                    <input id="address" type="text" th:field="*{address}" placeholder="Địa chỉ cư trú hiện tại">
+                    <span class="error" th:if="${#fields.hasErrors('address')}" th:errors="*{address}"></span>
+                </div>
             </div>
             <input type="hidden" th:if="${!isStudent}" th:field="*{address}">
 
-            <div class="form-actions">
-                <button type="submit" class="button btn-save"><i class="fas fa-save"></i> Lưu thay đổi</button>
+            <div class="form-actions profile-actions">
                 <a th:href="${isStudent} ? @{/student/profile} : @{/dashboard}" class="button btn-cancel">
                     <i class="fas fa-arrow-left"></i> Quay lại
                 </a>
+                <button type="submit" class="button btn-save"><i class="fas fa-save"></i> Lưu thay đổi</button>
             </div>
         </form>
     </div>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -14,23 +14,25 @@
 
         <div class="header-right">
             <div class="user-profile" sec:authorize="isAuthenticated()" th:with="auth=${#authentication}">
-                <div class="user-avatar"
-                     th:text="${auth != null && auth.name != null && auth.name.length() > 0 ? auth.name.substring(0,1).toUpperCase() : 'U'}">U</div>
-                <div class="user-meta">
-                    <span class="user-name"
-                          th:text="${auth != null && auth.name != null ? auth.name : 'Người dùng'}">Người dùng</span>
-                    <!-- Hiển thị danh sách roles -->
-                    <span th:text="${#strings.arrayJoin(auth.authorities.![authority], ', ')}"></span>
-                </div>
-                <div class="user-actions">
-                    <a class="change-password-link" th:href="@{/account/profile}" sec:authorize="isAuthenticated()">
-                        Cập nhật thông tin
+                <button type="button" class="user-trigger" aria-haspopup="true" aria-expanded="false">
+                    <span class="user-avatar"
+                          th:text="${auth != null && auth.name != null && auth.name.length() > 0 ? auth.name.substring(0,1).toUpperCase() : 'U'}">U</span>
+                    <span class="user-meta">
+                        <span class="user-name"
+                              th:text="${auth != null && auth.name != null ? auth.name : 'Người dùng'}">Người dùng</span>
+                        <span class="user-role" th:text="${#strings.arrayJoin(auth.authorities.![authority], ', ')}"></span>
+                    </span>
+                    <span class="user-caret" aria-hidden="true">▾</span>
+                </button>
+                <div class="user-dropdown" role="menu">
+                    <a class="user-dropdown-link" th:href="@{/account/profile}" role="menuitem" sec:authorize="isAuthenticated()">
+                        <span>Cập nhật thông tin</span>
                     </a>
-                    <a class="change-password-link" th:href="@{/account/password}" sec:authorize="hasAnyRole('ADMIN','STAFF','STUDENT')">
-                        Đổi mật khẩu
+                    <a class="user-dropdown-link" th:href="@{/account/password}" role="menuitem" sec:authorize="hasAnyRole('ADMIN','STAFF','STUDENT')">
+                        <span>Đổi mật khẩu</span>
                     </a>
-                    <form th:action="@{/logout}" method="post" class="logout-form">
-                        <button type="submit" class="logout-btn">Đăng xuất</button>
+                    <form th:action="@{/logout}" method="post" role="none">
+                        <button type="submit" class="user-dropdown-link user-dropdown-logout" role="menuitem">Đăng xuất</button>
                     </form>
                 </div>
             </div>
@@ -56,6 +58,45 @@
             if (popup) {
                 popup.style.display = 'flex';
                 setTimeout(function() { popup.style.display = 'none'; }, 3000);
+            }
+
+            const userProfile = document.querySelector('.user-profile');
+            if (userProfile) {
+                const trigger = userProfile.querySelector('.user-trigger');
+                const dropdown = userProfile.querySelector('.user-dropdown');
+                const toggleMenu = (expand) => {
+                    const isOpen = expand !== undefined ? expand : !userProfile.classList.contains('open');
+                    userProfile.classList.toggle('open', isOpen);
+                    if (trigger) {
+                        trigger.setAttribute('aria-expanded', isOpen);
+                    }
+                    if (dropdown) {
+                        dropdown.hidden = !isOpen;
+                    }
+                };
+
+                if (dropdown) {
+                    dropdown.hidden = true;
+                }
+
+                if (trigger) {
+                    trigger.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        toggleMenu();
+                    });
+                }
+
+                document.addEventListener('click', (event) => {
+                    if (!userProfile.contains(event.target)) {
+                        toggleMenu(false);
+                    }
+                });
+
+                document.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') {
+                        toggleMenu(false);
+                    }
+                });
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- replace the inline account actions in the header with a dropdown menu that opens when the user profile is clicked
- refresh the account profile page with a highlighted summary card and a modernized grid layout for editing contact information
- add supporting styles and responsive tweaks for the new profile components

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68daa7232df4832687ade8b9143fe1d1