### PR TITLE
Display current user's avatar in header menu

### DIFF
--- a/src/main/java/com/example/dorm/controller/GlobalModelAttributes.java
+++ b/src/main/java/com/example/dorm/controller/GlobalModelAttributes.java
@@ -1,0 +1,28 @@
+package com.example.dorm.controller;
+
+import com.example.dorm.model.User;
+import com.example.dorm.service.UserService;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class GlobalModelAttributes {
+
+    private final UserService userService;
+
+    public GlobalModelAttributes(UserService userService) {
+        this.userService = userService;
+    }
+
+    @ModelAttribute("currentUser")
+    public User populateCurrentUser(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated() ||
+                authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+
+        return userService.findByUsername(authentication.getName()).orElse(null);
+    }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -132,6 +132,18 @@ body {
     flex-shrink: 0;
 }
 
+.user-avatar.has-image {
+    background: none;
+}
+
+.user-avatar img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+}
+
 .user-meta {
     display: flex;
     flex-direction: column;

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -16,7 +16,13 @@
             <div class="user-profile" sec:authorize="isAuthenticated()" th:with="auth=${#authentication}">
                 <button type="button" class="user-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="user-menu">
     <span class="user-avatar"
-          th:text="${auth != null && auth.name != null && auth.name.length() > 0 ? auth.name.substring(0,1).toUpperCase() : 'U'}">U</span>
+          th:classappend="${currentUser != null && currentUser.avatarFilename != null ? ' has-image' : ''}">
+      <img th:if="${currentUser != null && currentUser.avatarFilename != null}"
+           th:src="@{/uploads/avatars/{file}(file=${currentUser.avatarFilename})}"
+           th:alt="${auth != null && auth.name != null ? 'Ảnh đại diện của ' + auth.name : 'Ảnh đại diện người dùng'}" />
+      <span th:unless="${currentUser != null && currentUser.avatarFilename != null}"
+            th:text="${auth != null && auth.name != null && auth.name.length() > 0 ? auth.name.substring(0,1).toUpperCase() : 'U'}">U</span>
+    </span>
                     <span class="user-meta">
       <span class="user-name" th:text="${auth != null && auth.name != null ? auth.name : 'Người dùng'}">Người dùng</span>
       <span class="user-role" th:text="${#strings.arrayJoin(auth.authorities.![authority], ', ')}"></span>


### PR DESCRIPTION
## Summary
- expose the authenticated user as a shared model attribute so views can access profile data
- render the user avatar in the header when an uploaded profile image is available while keeping the initial as a fallback
- update header styling to properly display circular avatar images

## Testing
- mvn -q -DskipTests package *(fails: Unable to resolve Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68db8a72c17483268dfb6e070bdfb85b