### PR TITLE
Implement dorm registration periods workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ src/main/java/com/example/dorm
 
 Các controller chỉ nhận request và chuyển tiếp tới service. Service thực hiện kiểm tra nghiệp vụ (ví dụ: giới hạn số giường phòng, ràng buộc duy nhất của mã sinh viên, chuẩn hóa mật khẩu dataset) trước khi gọi repository. Lỗi nghiệp vụ sẽ được bắt bởi `GlobalExceptionHandler` và trả về trang lỗi thân thiện.
 
+👉 Tham khảo thêm tài liệu **[Thiết kế luồng đăng ký KTX](docs/ktx-registration-flow.md)** để xem chi tiết quy trình mở đợt, sinh viên nộp đơn và đóng đợt đăng ký trong hệ thống.
+
 ## 🚀 Hướng dẫn chạy ứng dụng
 1. Cài đặt **JDK 21** và **Maven 3.9+**.
 2. (Tuỳ chọn) Đặt biến môi trường `SPRING_PROFILES_ACTIVE=mysql` nếu muốn kết nối MySQL. Cấu hình kết nối nằm trong `application-mysql.properties`.

--- a/docs/ktx-registration-flow.md
+++ b/docs/ktx-registration-flow.md
@@ -1,0 +1,128 @@
+# Thiết kế luồng đăng ký Ký túc xá
+
+Tài liệu mô tả thiết kế nghiệp vụ và các thành phần hệ thống phục vụ quy trình đăng ký KTX gồm các bước mở đợt đăng ký, sinh viên nộp đơn và đóng đợt đăng ký.
+
+## 1. Bối cảnh và mục tiêu
+- **Mục tiêu**: đảm bảo sinh viên có thể đăng ký chỗ ở đúng khung thời gian, dữ liệu được lưu trữ an toàn và ban quản lý dễ dàng xét duyệt.
+- **Phạm vi**: các chức năng liên quan đến một đợt đăng ký KTX từ khi mở đến khi đóng.
+
+## 2. Các tác nhân
+| Tác nhân | Quyền hạn chính |
+|----------|------------------|
+| Quản trị viên/nhân viên KTX | Mở/đóng đợt đăng ký, theo dõi số lượng đơn, xét duyệt sau khi đợt kết thúc. |
+| Sinh viên | Đăng nhập, điền và gửi đơn đăng ký trong thời gian đợt mở. |
+| Hệ thống | Kiểm tra ràng buộc, lưu đơn đăng ký, thông báo kết quả thao tác. |
+
+## 3. Trạng thái và dữ liệu cốt lõi
+### 3.1 Thực thể chính
+- **RegistrationPeriod**
+  - Thuộc tính: `id`, `title`, `startDateTime`, `endDateTime`, `capacity`, `availableSlots`, `status {OPEN, CLOSED}`, `createdBy`.
+  - Ràng buộc: chỉ một bản ghi có `status=OPEN` tại một thời điểm.
+- **DormRoom** (tham chiếu khi xét duyệt, không dùng trực tiếp ở bước đăng ký nhưng cần để kiểm tra sức chứa tổng).
+- **Student**
+  - Thuộc tính: `studentCode`, `fullName`, `email`, `className`, `cohort`, `status {ACTIVE, SUSPENDED}`.
+- **DormApplication**
+  - Thuộc tính: `id`, `registrationPeriodId`, `studentId`, `submittedAt`, `status {DRAFT, SUBMITTED, CANCELLED, REJECTED, APPROVED}`, `desiredBuilding`, `desiredRoomType`, `motivation`, `attachments`.
+  - Ràng buộc: (registrationPeriodId, studentId) duy nhất; `status=SUBMITTED` khi sinh viên gửi thành công.
+
+### 3.2 Sơ đồ trạng thái đơn đăng ký
+```mermaid
+stateDiagram-v2
+    [*] --> DRAFT
+    DRAFT --> SUBMITTED: Sinh viên nhấn "Nộp đơn"
+    DRAFT --> CANCELLED: Sinh viên thoát không lưu
+    SUBMITTED --> APPROVED: Nhân viên xét duyệt & phân phòng
+    SUBMITTED --> REJECTED: Nhân viên từ chối
+    SUBMITTED --> CANCELLED: Đợt đăng ký bị đóng trước khi xét duyệt
+    APPROVED --> [*]
+    REJECTED --> [*]
+    CANCELLED --> [*]
+```
+
+## 4. Dòng nghiệp vụ chi tiết
+### 4.1 Mở đợt đăng ký
+1. Quản trị viên đăng nhập, truy cập màn hình "Quản lý đợt đăng ký".
+2. Chọn "Tạo đợt mới", nhập thời gian bắt đầu/kết thúc, chỉ tiêu.
+3. Hệ thống kiểm tra: không có đợt `OPEN`, `startDateTime < endDateTime`, `capacity > 0`.
+4. Nếu hợp lệ, hệ thống tạo bản ghi `RegistrationPeriod` với `status=OPEN`, khởi tạo `availableSlots=capacity`.
+5. Ghi log audit và gửi thông báo (dashboard + email) cho sinh viên.
+
+### 4.2 Sinh viên truy cập đăng ký
+1. Sinh viên đăng nhập qua cổng sinh viên.
+2. Dashboard kiểm tra:
+   - Tồn tại `RegistrationPeriod` trạng thái `OPEN`.
+   - Sinh viên chưa có `DormApplication` trạng thái `SUBMITTED` trong kỳ này.
+3. Nếu đủ điều kiện, hiển thị nút "Đăng ký KTX" cùng thông tin đợt (thời gian, số chỗ còn lại, hướng dẫn).
+4. Nếu không, thông báo lý do (chưa mở đợt, đã đăng ký, tài khoản bị khóa...).
+
+### 4.3 Sinh viên điền đơn
+1. Form đăng ký hiển thị các trường bắt buộc: thông tin cá nhân tự động điền từ hồ sơ, lựa chọn khu/loại phòng, lý do, upload file.
+2. Client thực hiện validation cơ bản (trống, định dạng email, kích thước file).
+3. Dữ liệu tạm thời lưu trên session/State của form; chưa ghi xuống DB.
+4. Sinh viên có thể lưu nháp (`status=DRAFT`) nếu cần chỉnh sửa.
+
+### 4.4 Sinh viên nộp đơn
+1. Sinh viên nhấn "Nộp đơn".
+2. Backend nhận request `POST /registration-periods/{id}/applications`.
+3. Kiểm tra:
+   - Đợt vẫn `OPEN` và `currentTime` trong khoảng `[startDateTime, endDateTime]`.
+   - `availableSlots > 0`.
+   - Sinh viên chưa có đơn `SUBMITTED`.
+   - Thông tin form hợp lệ.
+4. Nếu hợp lệ:
+   - Lưu `DormApplication` với `status=SUBMITTED`, `submittedAt=now`.
+   - Giảm `availableSlots` của `RegistrationPeriod` (sử dụng khóa lạc quan để tránh overbooking).
+   - Ghi nhận lịch sử thao tác.
+5. Trả về phản hồi thành công (JSON/HTML) cùng mã đơn.
+
+### 4.5 Thông báo xác nhận
+1. Sau khi lưu đơn, backend gửi event `ApplicationSubmitted`.
+2. Listener gửi email + thông báo trong hệ thống cho sinh viên.
+3. Giao diện chuyển hướng tới trang kết quả hiển thị trạng thái "Đã tiếp nhận - chờ duyệt".
+4. Sinh viên có thể theo dõi trạng thái trong "Đơn đã nộp".
+
+### 4.6 Đóng đợt đăng ký
+1. Khi tới `endDateTime` hoặc `availableSlots=0`, hệ thống tự động chuyển `status=CLOSED` thông qua scheduled job (chạy mỗi 5 phút).
+2. Quản trị viên cũng có thể nhấn "Đóng đợt" thủ công:
+   - Hệ thống xác nhận và cập nhật `status=CLOSED`.
+   - Từ chối các yêu cầu nộp đơn mới (trả mã lỗi 409 nếu gọi API).
+3. Toàn bộ đơn `SUBMITTED` giữ nguyên để chờ xét duyệt, đơn `DRAFT` bị chuyển `CANCELLED`.
+
+## 5. Giao diện và phân quyền
+- **Admin Dashboard**: danh sách đợt đăng ký, số lượng đã đăng ký, nút mở/đóng.
+- **Student Portal**: nút truy cập đơn trong thời gian mở, form nhiều bước (review thông tin -> chọn khu -> xác nhận).
+- **Access Control**:
+  - API tạo/đóng đợt: chỉ role `ADMIN` hoặc `STAFF`.
+  - API nộp đơn: role `STUDENT` với trạng thái tài khoản `ACTIVE`.
+
+## 6. Kiến trúc kỹ thuật
+- **Controller layer**:
+  - `RegistrationPeriodController`: REST + view cho admin.
+  - `DormApplicationController`: form cho sinh viên.
+- **Service layer**:
+  - `RegistrationPeriodService`: quản lý trạng thái, đồng bộ số lượng chỗ.
+  - `DormApplicationService`: chứa nghiệp vụ kiểm tra và lưu đơn.
+- **Repository layer**: CRUD với `Spring Data JPA`, dùng khóa lạc quan (`@Version`).
+- **Validation**: Hibernate Validator cho các ràng buộc bắt buộc.
+- **Scheduled job**: `RegistrationPeriodScheduler` đóng đợt khi quá hạn.
+- **Event**: `ApplicationSubmittedEvent` + listener gửi thông báo.
+
+## 7. Trường hợp lỗi & thông báo
+| Tình huống | Cách xử lý |
+|------------|-----------|
+| Không có đợt mở | Trả về thông báo "Chưa có đợt đăng ký" trên UI. |
+| Hết chỉ tiêu | Nút nộp đơn bị vô hiệu hóa, API trả HTTP 409. |
+| Sinh viên đã đăng ký | Hiển thị trạng thái đơn hiện tại, không cho tạo mới. |
+| Đăng nhập sai quyền | Trả HTTP 403 và chuyển hướng tới trang đăng nhập. |
+| Đóng đột ngột khi đang điền form | Khi submit, kiểm tra lại trạng thái, trả thông báo "Đợt đã kết thúc". |
+
+## 8. Nhật ký và giám sát
+- Ghi log audit cho hành động mở/đóng đợt, nộp đơn, thay đổi trạng thái xét duyệt.
+- Dashboard thống kê: số đơn theo trạng thái, biểu đồ tiến độ đăng ký.
+- Cảnh báo email khi gần hết chỉ tiêu (ví dụ: còn < 10%).
+
+## 9. Mở rộng tương lai
+- Tích hợp cổng thanh toán phí đặt cọc ngay sau khi đơn được duyệt.
+- Cho phép sinh viên ưu tiên nhiều loại phòng và hệ thống xét tự động.
+- Cung cấp API công khai để hệ thống khác (cổng thông tin trường) truy vấn trạng thái đăng ký.
+

--- a/src/main/java/com/example/dorm/controller/DormRegistrationPeriodController.java
+++ b/src/main/java/com/example/dorm/controller/DormRegistrationPeriodController.java
@@ -1,0 +1,58 @@
+package com.example.dorm.controller;
+
+import com.example.dorm.model.DormRegistrationPeriod;
+import com.example.dorm.service.DormRegistrationPeriodService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/registrations/periods")
+public class DormRegistrationPeriodController {
+
+    private final DormRegistrationPeriodService dormRegistrationPeriodService;
+
+    public DormRegistrationPeriodController(DormRegistrationPeriodService dormRegistrationPeriodService) {
+        this.dormRegistrationPeriodService = dormRegistrationPeriodService;
+    }
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("periods", dormRegistrationPeriodService.findAll());
+        model.addAttribute("periodForm", new DormRegistrationPeriod());
+        model.addAttribute("activePeriod", dormRegistrationPeriodService.getOpenPeriod().orElse(null));
+        return "registrations/periods";
+    }
+
+    @PostMapping
+    public String openPeriod(@ModelAttribute("periodForm") DormRegistrationPeriod period,
+                             RedirectAttributes redirectAttributes) {
+        try {
+            dormRegistrationPeriodService.openPeriod(period);
+            redirectAttributes.addFlashAttribute("message", "Đã mở đợt đăng ký mới thành công.");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+        } catch (Exception ex) {
+            redirectAttributes.addFlashAttribute("message", "Không thể mở đợt đăng ký: " + ex.getMessage());
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+        }
+        return "redirect:/registrations/periods";
+    }
+
+    @PostMapping("/{id}/close")
+    public String closePeriod(@PathVariable Long id, RedirectAttributes redirectAttributes) {
+        try {
+            dormRegistrationPeriodService.closePeriod(id);
+            redirectAttributes.addFlashAttribute("message", "Đã đóng đợt đăng ký.");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+        } catch (Exception ex) {
+            redirectAttributes.addFlashAttribute("message", "Không thể đóng đợt đăng ký: " + ex.getMessage());
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+        }
+        return "redirect:/registrations/periods";
+    }
+}

--- a/src/main/java/com/example/dorm/controller/DormRegistrationRequestController.java
+++ b/src/main/java/com/example/dorm/controller/DormRegistrationRequestController.java
@@ -1,7 +1,9 @@
 package com.example.dorm.controller;
 
+import com.example.dorm.model.DormRegistrationPeriod;
 import com.example.dorm.model.DormRegistrationRequest;
 import com.example.dorm.model.DormRegistrationStatus;
+import com.example.dorm.service.DormRegistrationPeriodService;
 import com.example.dorm.service.DormRegistrationRequestService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -20,9 +22,12 @@ import java.util.List;
 public class DormRegistrationRequestController {
 
     private final DormRegistrationRequestService dormRegistrationRequestService;
+    private final DormRegistrationPeriodService dormRegistrationPeriodService;
 
-    public DormRegistrationRequestController(DormRegistrationRequestService dormRegistrationRequestService) {
+    public DormRegistrationRequestController(DormRegistrationRequestService dormRegistrationRequestService,
+                                            DormRegistrationPeriodService dormRegistrationPeriodService) {
         this.dormRegistrationRequestService = dormRegistrationRequestService;
+        this.dormRegistrationPeriodService = dormRegistrationPeriodService;
     }
 
     @ModelAttribute("statusOptions")
@@ -32,12 +37,17 @@ public class DormRegistrationRequestController {
 
     @GetMapping
     public String list(@RequestParam(value = "status", required = false) String status,
+                       @RequestParam(value = "periodId", required = false) Long periodId,
                        @RequestParam(value = "query", required = false) String keyword,
                        Model model) {
-        List<DormRegistrationRequest> requests = dormRegistrationRequestService.findAll(status, keyword);
+        List<DormRegistrationRequest> requests = dormRegistrationRequestService.findAll(periodId, status, keyword);
+        List<DormRegistrationPeriod> periods = dormRegistrationPeriodService.findAll();
         model.addAttribute("requests", requests);
         model.addAttribute("selectedStatus", status != null ? status.toUpperCase() : "");
         model.addAttribute("searchQuery", keyword != null ? keyword : "");
+        model.addAttribute("periods", periods);
+        model.addAttribute("selectedPeriodId", periodId);
+        model.addAttribute("activePeriod", dormRegistrationPeriodService.getOpenPeriod().orElse(null));
         return "registrations/list";
     }
 

--- a/src/main/java/com/example/dorm/model/DormRegistrationPeriod.java
+++ b/src/main/java/com/example/dorm/model/DormRegistrationPeriod.java
@@ -1,0 +1,142 @@
+package com.example.dorm.model;
+
+import jakarta.persistence.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class DormRegistrationPeriod {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endTime;
+
+    private Integer capacity;
+
+    @Column(length = 2000)
+    private String notes;
+
+    @Enumerated(EnumType.STRING)
+    private DormRegistrationPeriodStatus status = DormRegistrationPeriodStatus.SCHEDULED;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Transient
+    private Long submittedCount = 0L;
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        if (this.startTime == null) {
+            this.startTime = createdAt;
+        }
+        if (this.status == null) {
+            this.status = DormRegistrationPeriodStatus.SCHEDULED;
+        }
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public Integer getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(Integer capacity) {
+        this.capacity = capacity;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public DormRegistrationPeriodStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(DormRegistrationPeriodStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public boolean isOpen() {
+        return this.status == DormRegistrationPeriodStatus.OPEN;
+    }
+
+    public boolean isExpired() {
+        return this.endTime != null && this.endTime.isBefore(LocalDateTime.now());
+    }
+
+    public Long getSubmittedCount() {
+        return submittedCount;
+    }
+
+    public void setSubmittedCount(Long submittedCount) {
+        this.submittedCount = submittedCount;
+    }
+}

--- a/src/main/java/com/example/dorm/model/DormRegistrationPeriodStatus.java
+++ b/src/main/java/com/example/dorm/model/DormRegistrationPeriodStatus.java
@@ -1,0 +1,17 @@
+package com.example.dorm.model;
+
+public enum DormRegistrationPeriodStatus {
+    SCHEDULED("Đã lên lịch"),
+    OPEN("Đang mở"),
+    CLOSED("Đã đóng");
+
+    private final String displayName;
+
+    DormRegistrationPeriodStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/example/dorm/model/DormRegistrationRequest.java
+++ b/src/main/java/com/example/dorm/model/DormRegistrationRequest.java
@@ -17,6 +17,10 @@ public class DormRegistrationRequest {
     @JoinColumn(name = "student_id")
     private Student student;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "period_id")
+    private DormRegistrationPeriod period;
+
     @Column(length = 100)
     private String desiredRoomType;
 
@@ -42,6 +46,7 @@ public class DormRegistrationRequest {
     @PrePersist
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
         if (this.status == null) {
             this.status = DormRegistrationStatus.PENDING;
         }
@@ -66,6 +71,14 @@ public class DormRegistrationRequest {
 
     public void setStudent(Student student) {
         this.student = student;
+    }
+
+    public DormRegistrationPeriod getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(DormRegistrationPeriod period) {
+        this.period = period;
     }
 
     public String getDesiredRoomType() {

--- a/src/main/java/com/example/dorm/repository/DormRegistrationPeriodRepository.java
+++ b/src/main/java/com/example/dorm/repository/DormRegistrationPeriodRepository.java
@@ -1,0 +1,14 @@
+package com.example.dorm.repository;
+
+import com.example.dorm.model.DormRegistrationPeriod;
+import com.example.dorm.model.DormRegistrationPeriodStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DormRegistrationPeriodRepository extends JpaRepository<DormRegistrationPeriod, Long> {
+    Optional<DormRegistrationPeriod> findFirstByStatusOrderByStartTimeDesc(DormRegistrationPeriodStatus status);
+    boolean existsByStatus(DormRegistrationPeriodStatus status);
+    List<DormRegistrationPeriod> findAllByOrderByStartTimeDesc();
+}

--- a/src/main/java/com/example/dorm/repository/DormRegistrationRequestRepository.java
+++ b/src/main/java/com/example/dorm/repository/DormRegistrationRequestRepository.java
@@ -10,4 +10,8 @@ public interface DormRegistrationRequestRepository extends JpaRepository<DormReg
     List<DormRegistrationRequest> findByStudentIdOrderByCreatedAtDesc(Long studentId);
     List<DormRegistrationRequest> findAllByOrderByCreatedAtDesc();
     List<DormRegistrationRequest> findByStatusOrderByCreatedAtDesc(DormRegistrationStatus status);
+    List<DormRegistrationRequest> findByPeriodIdOrderByCreatedAtDesc(Long periodId);
+    List<DormRegistrationRequest> findByPeriodIdAndStatusOrderByCreatedAtDesc(Long periodId, DormRegistrationStatus status);
+    boolean existsByStudentIdAndPeriodId(Long studentId, Long periodId);
+    long countByPeriodId(Long periodId);
 }

--- a/src/main/java/com/example/dorm/service/DormRegistrationPeriodService.java
+++ b/src/main/java/com/example/dorm/service/DormRegistrationPeriodService.java
@@ -1,0 +1,112 @@
+package com.example.dorm.service;
+
+import com.example.dorm.model.DormRegistrationPeriod;
+import com.example.dorm.model.DormRegistrationPeriodStatus;
+import com.example.dorm.repository.DormRegistrationPeriodRepository;
+import com.example.dorm.repository.DormRegistrationRequestRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DormRegistrationPeriodService {
+
+    private final DormRegistrationPeriodRepository periodRepository;
+    private final DormRegistrationRequestRepository requestRepository;
+
+    public DormRegistrationPeriodService(DormRegistrationPeriodRepository periodRepository,
+                                         DormRegistrationRequestRepository requestRepository) {
+        this.periodRepository = periodRepository;
+        this.requestRepository = requestRepository;
+    }
+
+    public List<DormRegistrationPeriod> findAll() {
+        List<DormRegistrationPeriod> periods = periodRepository.findAllByOrderByStartTimeDesc();
+        periods.forEach(period -> period.setSubmittedCount(requestRepository.countByPeriodId(period.getId())));
+        return periods;
+    }
+
+    public Optional<DormRegistrationPeriod> getOpenPeriod() {
+        Optional<DormRegistrationPeriod> openPeriod = periodRepository
+                .findFirstByStatusOrderByStartTimeDesc(DormRegistrationPeriodStatus.OPEN);
+
+        if (openPeriod.isPresent()) {
+            DormRegistrationPeriod period = openPeriod.get();
+            if (period.isExpired()) {
+                period.setStatus(DormRegistrationPeriodStatus.CLOSED);
+                if (period.getEndTime() == null) {
+                    period.setEndTime(LocalDateTime.now());
+                }
+                periodRepository.save(period);
+                return Optional.empty();
+            }
+            long submitted = requestRepository.countByPeriodId(period.getId());
+            period.setSubmittedCount(submitted);
+            if (period.getCapacity() != null && submitted >= period.getCapacity()) {
+                period.setStatus(DormRegistrationPeriodStatus.CLOSED);
+                if (period.getEndTime() == null) {
+                    period.setEndTime(LocalDateTime.now());
+                }
+                periodRepository.save(period);
+                return Optional.empty();
+            }
+        }
+
+        return openPeriod;
+    }
+
+    public long countSubmittedRequests(Long periodId) {
+        return requestRepository.countByPeriodId(periodId);
+    }
+
+    @Transactional
+    public DormRegistrationPeriod openPeriod(DormRegistrationPeriod period) {
+        if (periodRepository.existsByStatus(DormRegistrationPeriodStatus.OPEN)) {
+            throw new IllegalStateException("Đang có đợt đăng ký khác mở. Vui lòng đóng trước khi tạo đợt mới.");
+        }
+
+        if (period.getName() == null || period.getName().isBlank()) {
+            throw new IllegalArgumentException("Vui lòng nhập tên đợt đăng ký.");
+        }
+
+        if (period.getCapacity() != null && period.getCapacity() < 1) {
+            throw new IllegalArgumentException("Chỉ tiêu phải lớn hơn 0.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (period.getStartTime() == null || period.getStartTime().isAfter(now)) {
+            period.setStartTime(now);
+        }
+
+        if (period.getEndTime() != null && period.getEndTime().isBefore(period.getStartTime())) {
+            throw new IllegalArgumentException("Thời gian kết thúc phải sau thời gian bắt đầu.");
+        }
+
+        period.setStatus(DormRegistrationPeriodStatus.OPEN);
+        DormRegistrationPeriod saved = periodRepository.save(period);
+        saved.setSubmittedCount(0L);
+        return saved;
+    }
+
+    @Transactional
+    public DormRegistrationPeriod closePeriod(Long id) {
+        DormRegistrationPeriod period = periodRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy đợt đăng ký."));
+
+        if (period.getStatus() == DormRegistrationPeriodStatus.CLOSED) {
+            return period;
+        }
+
+        period.setStatus(DormRegistrationPeriodStatus.CLOSED);
+        if (period.getEndTime() == null) {
+            period.setEndTime(LocalDateTime.now());
+        }
+
+        DormRegistrationPeriod saved = periodRepository.save(period);
+        saved.setSubmittedCount(requestRepository.countByPeriodId(saved.getId()));
+        return saved;
+    }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1811,7 +1811,62 @@ h2 {
         align-items: stretch;
     }
 
-    .profile-actions .button {
-        width: 100%;
-    }
+.profile-actions .button {
+    width: 100%;
+}
+}
+
+/* ======== REGISTRATION PERIOD COMPONENTS ======== */
+.status-banner {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(59, 130, 246, 0.08);
+    border: 1px solid rgba(59, 130, 246, 0.2);
+    border-radius: var(--radius-md);
+    color: var(--primary-dark);
+    font-size: 0.9rem;
+}
+
+.status-banner.warning {
+    background: rgba(249, 115, 22, 0.1);
+    border-color: rgba(249, 115, 22, 0.2);
+    color: #b45309;
+}
+
+.status-banner.info {
+    background: rgba(6, 182, 212, 0.1);
+    border-color: rgba(6, 182, 212, 0.2);
+    color: #0e7490;
+}
+
+.status-banner + .status-banner {
+    margin-left: 0;
+    margin-top: 0.5rem;
+}
+
+.card {
+    background: var(--bg-secondary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+}
+
+.card-header {
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(14, 165, 233, 0.08));
+}
+
+.card-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--primary-dark);
+}
+
+.card-body {
+    padding: 1.5rem;
 }

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -48,6 +48,10 @@
                     <i class="fas fa-clipboard-list"></i>
                     <span>Đăng ký KTX</span>
                 </a>
+                <a th:href="@{/registrations/periods}" class="sidebar-link">
+                    <i class="fas fa-calendar-check"></i>
+                    <span>Đợt đăng ký</span>
+                </a>
                 <a th:href="@{/maintenance}" class="sidebar-link">
                     <i class="fas fa-headset"></i>
                     <span>Yêu cầu hỗ trợ</span>

--- a/src/main/resources/templates/registrations/list.html
+++ b/src/main/resources/templates/registrations/list.html
@@ -17,10 +17,28 @@
             <div>
                 <h2>Yêu cầu đăng ký ký túc xá</h2>
                 <p class="text-muted">Theo dõi và xử lý các yêu cầu đăng ký chỗ ở từ sinh viên</p>
+                <div class="status-banner" th:if="${activePeriod != null}">
+                    <strong th:text="${'Đợt đang mở: ' + activePeriod.name}"></strong>
+                    <span th:text="${activePeriod.endTime != null ? ' • Đóng: ' + #temporals.format(activePeriod.endTime, 'dd/MM/yyyy HH:mm') : ' • Chưa có thời gian đóng'}"></span>
+                    <span th:if="${activePeriod.capacity != null}" th:text="${' • Chỉ tiêu: ' + activePeriod.capacity}"></span>
+                </div>
+                <div class="status-banner warning" th:if="${activePeriod == null}">
+                    Hiện không có đợt đăng ký KTX nào mở. Hãy tạo đợt mới khi sẵn sàng.
+                </div>
             </div>
         </div>
 
         <form class="filter-bar" method="get">
+            <div class="filter-group">
+                <label for="periodId">Đợt đăng ký</label>
+                <select id="periodId" name="periodId">
+                    <option value="">Tất cả</option>
+                    <option th:each="period : ${periods}"
+                            th:value="${period.id}"
+                            th:selected="${selectedPeriodId != null and period.id == selectedPeriodId}"
+                            th:text="${period.name}"></option>
+                </select>
+            </div>
             <div class="filter-group">
                 <label for="status">Trạng thái</label>
                 <select id="status" name="status">
@@ -46,6 +64,7 @@
                 <thead>
                 <tr>
                     <th>Mã yêu cầu</th>
+                    <th>Đợt đăng ký</th>
                     <th>Sinh viên</th>
                     <th>Loại phòng</th>
                     <th>Ngày dự kiến</th>
@@ -58,6 +77,7 @@
                 <tbody>
                 <tr th:each="request : ${requests}" class="table-row">
                     <td th:text="${request.id}"></td>
+                    <td th:text="${request.period != null ? request.period.name : '-'}"></td>
                     <td>
                         <div class="table-meta">
                             <strong th:text="${request.student != null ? request.student.name : 'Không rõ'}"></strong>
@@ -80,7 +100,7 @@
                     </td>
                 </tr>
                 <tr th:if="${#lists.isEmpty(requests)}">
-                    <td colspan="8" class="text-center">Chưa có yêu cầu nào.</td>
+                    <td colspan="9" class="text-center">Chưa có yêu cầu nào.</td>
                 </tr>
                 </tbody>
             </table>

--- a/src/main/resources/templates/registrations/periods.html
+++ b/src/main/resources/templates/registrations/periods.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Quản lý đợt đăng ký KTX</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="fragments/sidebar :: sidebar"></div>
+<div th:replace="~{fragments/header :: popup}"></div>
+
+<div class="content-with-sidebar">
+    <div class="container">
+        <div class="page-header">
+            <div>
+                <h2>Đợt đăng ký ký túc xá</h2>
+                <p class="text-muted">Mở/đóng đợt đăng ký để sinh viên nộp hồ sơ trong khung thời gian phù hợp</p>
+                <div class="status-banner" th:if="${activePeriod != null}">
+                    <strong th:text="${'Đang mở: ' + activePeriod.name}"></strong>
+                    <span th:text="${activePeriod.startTime != null ? ' • Mở: ' + #temporals.format(activePeriod.startTime, 'dd/MM/yyyy HH:mm') : ''}"></span>
+                    <span th:text="${activePeriod.endTime != null ? ' • Đóng: ' + #temporals.format(activePeriod.endTime, 'dd/MM/yyyy HH:mm') : ' • Chưa đặt thời gian đóng'}"></span>
+                    <span th:if="${activePeriod.capacity != null}" th:text="${' • Chỉ tiêu: ' + activePeriod.capacity}"></span>
+                </div>
+                <div class="status-banner warning" th:if="${activePeriod == null}">
+                    Hiện chưa có đợt đăng ký nào mở.
+                </div>
+            </div>
+        </div>
+
+        <div th:if="${message != null}" th:class="'alert ' + (${alertClass} != null ? ${alertClass} : 'alert-info')" th:text="${message}"></div>
+
+        <div class="card">
+            <div class="card-header">
+                <h3>Mở đợt đăng ký mới</h3>
+            </div>
+            <div class="card-body">
+                <form class="form-grid" th:object="${periodForm}" method="post">
+                    <div class="form-group">
+                        <label for="name">Tên đợt</label>
+                        <input id="name" type="text" th:field="*{name}" placeholder="Ví dụ: Đợt HK1 2025" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="startTime">Thời gian mở</label>
+                        <input id="startTime" type="datetime-local" th:field="*{startTime}">
+                        <small class="text-muted">Để trống để mở ngay bây giờ</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="endTime">Thời gian đóng</label>
+                        <input id="endTime" type="datetime-local" th:field="*{endTime}">
+                    </div>
+                    <div class="form-group">
+                        <label for="capacity">Chỉ tiêu hồ sơ</label>
+                        <input id="capacity" type="number" min="1" th:field="*{capacity}" placeholder="Ví dụ: 200">
+                    </div>
+                    <div class="form-group form-group-full">
+                        <label for="notes">Ghi chú</label>
+                        <textarea id="notes" rows="2" th:field="*{notes}" placeholder="Thông tin bổ sung cho đợt đăng ký"></textarea>
+                    </div>
+                    <div class="form-actions">
+                        <button class="button btn-add" type="submit">
+                            <i class="fas fa-door-open"></i> Mở đợt đăng ký
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="table-wrapper" style="margin-top: 2rem;">
+            <table>
+                <thead>
+                <tr>
+                    <th>Tên đợt</th>
+                    <th>Thời gian mở</th>
+                    <th>Thời gian đóng</th>
+                    <th>Chỉ tiêu</th>
+                    <th>Ghi chú</th>
+                    <th>Trạng thái</th>
+                    <th>Hồ sơ đã nhận</th>
+                    <th>Hành động</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="period : ${periods}">
+                    <td th:text="${period.name}"></td>
+                    <td th:text="${period.startTime != null ? #temporals.format(period.startTime, 'dd/MM/yyyy HH:mm') : '-'}"></td>
+                    <td th:text="${period.endTime != null ? #temporals.format(period.endTime, 'dd/MM/yyyy HH:mm') : '-'}"></td>
+                    <td th:text="${period.capacity != null ? period.capacity : '-'}"></td>
+                    <td th:text="${period.notes != null ? period.notes : '-'}" class="truncate"></td>
+                    <td>
+                        <span class="badge"
+                              th:classappend="${period.status.name() == 'OPEN' ? ' badge-success' : (period.status.name() == 'CLOSED' ? ' badge-danger' : ' badge-info')}">
+                            <span th:text="${period.status.displayName}"></span>
+                        </span>
+                    </td>
+                    <td th:text="${period.submittedCount}"></td>
+                    <td>
+                        <form th:if="${period.status.name() == 'OPEN'}" th:action="@{'/registrations/periods/' + ${period.id} + '/close'}" method="post">
+                            <button class="button btn-view" type="submit">
+                                <i class="fas fa-lock"></i> Đóng đợt
+                            </button>
+                        </form>
+                        <span th:if="${period.status.name() != 'OPEN'}" class="text-muted">Không khả dụng</span>
+                    </td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(periods)}">
+                    <td colspan="8" class="text-center">Chưa có đợt đăng ký nào được tạo.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/student/registration-form.html
+++ b/src/main/resources/templates/student/registration-form.html
@@ -16,6 +16,11 @@
             <div>
                 <h1>Gửi yêu cầu đăng ký KTX</h1>
                 <p class="text-muted">Chia sẻ nhu cầu ở ký túc xá để ban quản lý xem xét sắp xếp</p>
+                <div class="status-banner" th:if="${activeRegistrationPeriod != null}">
+                    <strong th:text="${activeRegistrationPeriod.name}"></strong>
+                    <span th:text="${activeRegistrationPeriod.endTime != null ? ' • Kết thúc: ' + #temporals.format(activeRegistrationPeriod.endTime, 'dd/MM/yyyy HH:mm') : ' • Chưa có thời gian kết thúc'}"></span>
+                    <span th:if="${activeRegistrationPeriod.capacity != null}" th:text="${' • Chỉ tiêu: ' + activeRegistrationPeriod.capacity}"></span>
+                </div>
             </div>
         </div>
 

--- a/src/main/resources/templates/student/registration-list.html
+++ b/src/main/resources/templates/student/registration-list.html
@@ -16,10 +16,26 @@
             <div>
                 <h1>Yêu cầu đăng ký ký túc xá</h1>
                 <p class="text-muted">Theo dõi trạng thái các yêu cầu đăng ký hoặc chuyển đổi chỗ ở</p>
+                <div class="status-banner" th:if="${activeRegistrationPeriod != null}">
+                    <strong th:text="${activeRegistrationPeriod.name}"></strong>
+                    <span th:text="${activeRegistrationPeriod.endTime != null ? ' • Kết thúc: ' + #temporals.format(activeRegistrationPeriod.endTime, 'dd/MM/yyyy HH:mm') : ' • Chưa có thời gian kết thúc'}"></span>
+                    <span th:if="${activeRegistrationPeriod.capacity != null}" th:text="${' • Chỉ tiêu: ' + activeRegistrationPeriod.capacity}"></span>
+                </div>
+                <div class="status-banner warning" th:if="${activeRegistrationPeriod == null}">
+                    Hiện chưa có đợt đăng ký KTX nào đang mở.
+                </div>
+                <div class="status-banner info" th:if="${alreadySubmittedInActivePeriod}">
+                    Bạn đã gửi đăng ký trong đợt hiện tại. Theo dõi phản hồi ở bảng dưới.
+                </div>
             </div>
-            <a class="button btn-add" th:href="@{/student/registrations/new}">
+            <a class="button btn-add" th:href="@{/student/registrations/new}"
+               th:if="${activeRegistrationPeriod != null && !alreadySubmittedInActivePeriod}">
                 <i class="fas fa-plus"></i> Gửi yêu cầu mới
             </a>
+            <button class="button btn-add" type="button" disabled
+                    th:if="${activeRegistrationPeriod == null || alreadySubmittedInActivePeriod}">
+                <i class="fas fa-plus"></i> Gửi yêu cầu mới
+            </button>
         </div>
 
         <div th:if="${message != null}" th:class="'alert ' + ${alertClass != null ? alertClass : 'alert-info'}" th:text="${message}"></div>
@@ -29,6 +45,7 @@
                 <thead>
                 <tr>
                     <th>Mã</th>
+                    <th>Đợt đăng ký</th>
                     <th>Loại phòng</th>
                     <th>Ngày dự kiến</th>
                     <th>Ghi chú</th>
@@ -41,6 +58,7 @@
                 <tbody>
                 <tr th:each="request : ${registrationRequests}">
                     <td th:text="${request.id}"></td>
+                    <td th:text="${request.period != null ? request.period.name : 'Không xác định'}"></td>
                     <td th:text="${request.desiredRoomType != null ? request.desiredRoomType : 'Chưa xác định'}"></td>
                     <td th:text="${request.expectedMoveInDate != null ? #temporals.format(request.expectedMoveInDate, 'dd/MM/yyyy') : '-'}"></td>
                     <td class="truncate" th:text="${request.additionalNotes != null ? request.additionalNotes : '-'}"></td>
@@ -56,7 +74,7 @@
                     <td th:text="${request.updatedAt != null ? #temporals.format(request.updatedAt, 'dd/MM/yyyy HH:mm') : '-'}"></td>
                 </tr>
                 <tr th:if="${#lists.isEmpty(registrationRequests)}">
-                    <td colspan="8" class="text-center">Bạn chưa gửi yêu cầu nào.</td>
+                    <td colspan="9" class="text-center">Bạn chưa gửi yêu cầu nào.</td>
                 </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
## Summary
- introduce a `DormRegistrationPeriod` domain model with repository, service, and controller endpoints so administrators can open and close housing registration windows with capacity and automatic closure checks
- require student requests to belong to the active period, block duplicate submissions, and surface period details and alerts in the student dashboard and registration pages
- enhance administrative UIs with period filtering/metrics, add a management screen for registration periods, update demo data, and style new status banners and cards

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download spring-boot-starter-parent from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68db9d9d604c83268f706943ccb30245