### PR TITLE
Prevent LazyInitializationException when rendering registration requests

### DIFF
--- a/src/main/java/com/example/dorm/repository/DormRegistrationRequestRepository.java
+++ b/src/main/java/com/example/dorm/repository/DormRegistrationRequestRepository.java
@@ -2,16 +2,28 @@ package com.example.dorm.repository;
 
 import com.example.dorm.model.DormRegistrationRequest;
 import com.example.dorm.model.DormRegistrationStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface DormRegistrationRequestRepository extends JpaRepository<DormRegistrationRequest, Long> {
+
+    @EntityGraph(attributePaths = {"period", "student"})
     List<DormRegistrationRequest> findByStudentIdOrderByCreatedAtDesc(Long studentId);
+
+    @EntityGraph(attributePaths = {"period", "student"})
     List<DormRegistrationRequest> findAllByOrderByCreatedAtDesc();
+
+    @EntityGraph(attributePaths = {"period", "student"})
     List<DormRegistrationRequest> findByStatusOrderByCreatedAtDesc(DormRegistrationStatus status);
+
+    @EntityGraph(attributePaths = {"period", "student"})
     List<DormRegistrationRequest> findByPeriodIdOrderByCreatedAtDesc(Long periodId);
+
+    @EntityGraph(attributePaths = {"period", "student"})
     List<DormRegistrationRequest> findByPeriodIdAndStatusOrderByCreatedAtDesc(Long periodId, DormRegistrationStatus status);
+
     boolean existsByStudentIdAndPeriodId(Long studentId, Long periodId);
     long countByPeriodId(Long periodId);
 }


### PR DESCRIPTION
## Summary
- eagerly load the period and student associations for dorm registration requests via JPA entity graphs
- prevent lazy initialization errors when rendering request data in Thymeleaf without enabling Open Session in View

## Testing
- mvn -q test *(fails: Non-resolvable parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dba7b04c1483269a03aa3791304404