### PR TITLE
Fix lazy loading on registration detail view

### DIFF
--- a/src/main/java/com/example/dorm/repository/DormRegistrationRequestRepository.java
+++ b/src/main/java/com/example/dorm/repository/DormRegistrationRequestRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DormRegistrationRequestRepository extends JpaRepository<DormRegistrationRequest, Long> {
 
@@ -26,4 +27,7 @@ public interface DormRegistrationRequestRepository extends JpaRepository<DormReg
 
     boolean existsByStudentIdAndPeriodId(Long studentId, Long periodId);
     long countByPeriodId(Long periodId);
+
+    @EntityGraph(attributePaths = {"period", "student", "student.room"})
+    Optional<DormRegistrationRequest> findWithStudentAndRoomById(Long id);
 }

--- a/src/main/java/com/example/dorm/service/DormRegistrationRequestService.java
+++ b/src/main/java/com/example/dorm/service/DormRegistrationRequestService.java
@@ -78,7 +78,7 @@ public class DormRegistrationRequestService {
     }
 
     public Optional<DormRegistrationRequest> findById(Long id) {
-        return repository.findById(id);
+        return repository.findWithStudentAndRoomById(id);
     }
 
     public boolean hasSubmissionInPeriod(Long studentId, Long periodId) {


### PR DESCRIPTION
## Summary
- load registration requests with student and room associations for the detail page
- ensure the service uses the eager fetch query to avoid LazyInitializationException when rendering Thymeleaf

## Testing
- mvn -DskipTests package *(fails: unable to download Spring Boot parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dbab1da400832692e8b4dac059bb4b