### PR TITLE
Add building management, maintenance assignment, and admin reporting

### DIFF
--- a/src/main/java/com/example/dorm/config/SecurityConfig.java
+++ b/src/main/java/com/example/dorm/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("/dashboard", "/dashboard/**").hasAnyRole("ADMIN", "STAFF")
                         .requestMatchers("/account/**").hasAnyRole("ADMIN", "STAFF", "STUDENT")
                         .requestMatchers("/maintenance/**", "/violations/**", "/registrations/**").hasAnyRole("ADMIN", "STAFF")
-                        .requestMatchers("/students/**", "/rooms/**", "/contracts/**", "/fees/**", "/users/**").hasRole("ADMIN")
+                        .requestMatchers("/students/**", "/rooms/**", "/contracts/**", "/fees/**", "/users/**", "/buildings/**", "/reports/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/src/main/java/com/example/dorm/controller/BuildingController.java
+++ b/src/main/java/com/example/dorm/controller/BuildingController.java
@@ -1,0 +1,96 @@
+package com.example.dorm.controller;
+
+import com.example.dorm.model.Building;
+import com.example.dorm.service.BuildingService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/buildings")
+public class BuildingController {
+
+    private final BuildingService buildingService;
+
+    public BuildingController(BuildingService buildingService) {
+        this.buildingService = buildingService;
+    }
+
+    @GetMapping
+    public String listBuildings(Model model) {
+        model.addAttribute("buildingSummaries", buildingService.getBuildingSummaries());
+        return "buildings/list";
+    }
+
+    @GetMapping("/new")
+    public String showCreateForm(Model model) {
+        model.addAttribute("building", new Building());
+        model.addAttribute("isEdit", false);
+        return "buildings/form";
+    }
+
+    @PostMapping
+    public String createBuilding(@ModelAttribute("building") Building building,
+                                 Model model,
+                                 RedirectAttributes redirectAttributes) {
+        try {
+            buildingService.createBuilding(building);
+            redirectAttributes.addFlashAttribute("message", "Thêm tòa nhà thành công!");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+            return "redirect:/buildings";
+        } catch (Exception e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            model.addAttribute("isEdit", false);
+            return "buildings/form";
+        }
+    }
+
+    @GetMapping("/{id}/edit")
+    public String showEditForm(@PathVariable Long id, Model model, RedirectAttributes redirectAttributes) {
+        try {
+            Building building = buildingService.getRequiredBuilding(id);
+            model.addAttribute("building", building);
+            model.addAttribute("isEdit", true);
+            return "buildings/form";
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("message", "Không tìm thấy tòa nhà");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+            return "redirect:/buildings";
+        }
+    }
+
+    @PostMapping("/{id}")
+    public String updateBuilding(@PathVariable Long id,
+                                 @ModelAttribute("building") Building building,
+                                 Model model,
+                                 RedirectAttributes redirectAttributes) {
+        try {
+            buildingService.updateBuilding(id, building);
+            redirectAttributes.addFlashAttribute("message", "Cập nhật tòa nhà thành công!");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+            return "redirect:/buildings";
+        } catch (Exception e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            model.addAttribute("isEdit", true);
+            return "buildings/form";
+        }
+    }
+
+    @GetMapping("/{id}/delete")
+    public String deleteBuilding(@PathVariable Long id, RedirectAttributes redirectAttributes) {
+        try {
+            buildingService.deleteBuilding(id);
+            redirectAttributes.addFlashAttribute("message", "Xóa tòa nhà thành công!");
+            redirectAttributes.addFlashAttribute("alertClass", "alert-success");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("message", "Không thể xóa tòa nhà: " + e.getMessage());
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+        }
+        return "redirect:/buildings";
+    }
+}

--- a/src/main/java/com/example/dorm/controller/ReportController.java
+++ b/src/main/java/com/example/dorm/controller/ReportController.java
@@ -1,0 +1,87 @@
+package com.example.dorm.controller;
+
+import com.example.dorm.dto.BuildingSummary;
+import com.example.dorm.model.Fee;
+import com.example.dorm.model.MaintenanceRequest;
+import com.example.dorm.model.PaymentStatus;
+import com.example.dorm.service.BuildingService;
+import com.example.dorm.service.FeeService;
+import com.example.dorm.service.MaintenanceRequestService;
+import com.example.dorm.service.RoomService;
+import com.example.dorm.service.StudentService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/reports")
+public class ReportController {
+
+    private final BuildingService buildingService;
+    private final RoomService roomService;
+    private final StudentService studentService;
+    private final MaintenanceRequestService maintenanceRequestService;
+    private final FeeService feeService;
+
+    public ReportController(BuildingService buildingService,
+                            RoomService roomService,
+                            StudentService studentService,
+                            MaintenanceRequestService maintenanceRequestService,
+                            FeeService feeService) {
+        this.buildingService = buildingService;
+        this.roomService = roomService;
+        this.studentService = studentService;
+        this.maintenanceRequestService = maintenanceRequestService;
+        this.feeService = feeService;
+    }
+
+    @GetMapping
+    public String overview(Model model) {
+        List<BuildingSummary> buildingSummaries = buildingService.getBuildingSummaries();
+        buildingSummaries = buildingSummaries.stream()
+                .sorted(Comparator.comparing(BuildingSummary::name, String.CASE_INSENSITIVE_ORDER))
+                .collect(Collectors.toList());
+
+        long totalCapacity = roomService.sumCapacity();
+        long occupiedBeds = roomService.countOccupiedBeds();
+        long availableBeds = Math.max(totalCapacity - occupiedBeds, 0);
+        double occupancyRate = totalCapacity == 0 ? 0 : (double) occupiedBeds / totalCapacity * 100.0;
+
+        List<MaintenanceRequest> allRequests = maintenanceRequestService.getAllRequests();
+        Map<String, Long> maintenanceSummary = allRequests.stream()
+                .collect(Collectors.groupingBy(MaintenanceRequest::getStatus, Collectors.counting()));
+
+        List<Fee> fees = feeService.getAllFees();
+        BigDecimal totalRevenue = fees.stream()
+                .map(Fee::getAmount)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal outstandingRevenue = fees.stream()
+                .filter(fee -> fee.getPaymentStatus() == PaymentStatus.UNPAID)
+                .map(Fee::getAmount)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        model.addAttribute("buildingSummaries", buildingSummaries);
+        model.addAttribute("buildingCount", buildingSummaries.size());
+        model.addAttribute("studentCount", studentService.countStudents());
+        model.addAttribute("totalCapacity", totalCapacity);
+        model.addAttribute("occupiedBeds", occupiedBeds);
+        model.addAttribute("availableBeds", availableBeds);
+        model.addAttribute("occupancyRate", occupancyRate);
+        model.addAttribute("maintenanceSummary", maintenanceSummary);
+        model.addAttribute("totalRequests", allRequests.size());
+        model.addAttribute("totalRevenue", totalRevenue);
+        model.addAttribute("outstandingRevenue", outstandingRevenue);
+
+        return "reports/overview";
+    }
+}

--- a/src/main/java/com/example/dorm/dto/BuildingSummary.java
+++ b/src/main/java/com/example/dorm/dto/BuildingSummary.java
@@ -1,0 +1,31 @@
+package com.example.dorm.dto;
+
+import com.example.dorm.model.Building;
+
+public record BuildingSummary(Long id,
+                               String code,
+                               String name,
+                               String address,
+                               Integer totalFloors,
+                               int roomCount,
+                               long capacity,
+                               long occupiedBeds) {
+
+    public BuildingSummary(Building building, int roomCount, long capacity, long occupiedBeds) {
+        this(building.getId(),
+                building.getCode(),
+                building.getName(),
+                building.getAddress(),
+                building.getTotalFloors(),
+                roomCount,
+                capacity,
+                occupiedBeds);
+    }
+
+    public double occupancyRate() {
+        if (capacity <= 0) {
+            return 0.0;
+        }
+        return (double) occupiedBeds / capacity * 100.0;
+    }
+}

--- a/src/main/java/com/example/dorm/model/Building.java
+++ b/src/main/java/com/example/dorm/model/Building.java
@@ -1,0 +1,87 @@
+package com.example.dorm.model;
+
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "building")
+public class Building {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String address;
+
+    @Column(length = 2000)
+    private String description;
+
+    private Integer totalFloors;
+
+    @OneToMany(mappedBy = "building")
+    @OrderBy("number ASC")
+    private List<Room> rooms = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Integer getTotalFloors() {
+        return totalFloors;
+    }
+
+    public void setTotalFloors(Integer totalFloors) {
+        this.totalFloors = totalFloors;
+    }
+
+    public List<Room> getRooms() {
+        return rooms;
+    }
+
+    public void setRooms(List<Room> rooms) {
+        this.rooms = rooms;
+    }
+}

--- a/src/main/java/com/example/dorm/model/Room.java
+++ b/src/main/java/com/example/dorm/model/Room.java
@@ -1,9 +1,11 @@
 package com.example.dorm.model;
 
 import jakarta.persistence.*;
+
 import java.util.List;
 
 @Entity
+@Table(name = "room")
 public class Room {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -11,22 +13,68 @@ public class Room {
     private String number;
     private String type;
     private int capacity;
-    private int price; // Giá phòng, có thể thêm nếu cần
+    private int price; // Giá phòng
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id")
+    private Building building;
 
     @OneToMany(mappedBy = "room")
     private List<Student> students;
 
-    // Getters and Setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
-    public String getNumber() { return number; }
-    public void setNumber(String number) { this.number = number; }
-    public String getType() { return type; }
-    public void setType(String type) { this.type = type; }
-    public int getCapacity() { return capacity; }
-    public void setCapacity(int capacity) { this.capacity = capacity; }
-    public int getPrice() { return price; }
-    public void setPrice(int price) { this.price = price; }
-    public List<Student> getStudents() { return students; }
-    public void setStudents(List<Student> students) { this.students = students; }
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(int capacity) {
+        this.capacity = capacity;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public void setPrice(int price) {
+        this.price = price;
+    }
+
+    public Building getBuilding() {
+        return building;
+    }
+
+    public void setBuilding(Building building) {
+        this.building = building;
+    }
+
+    public List<Student> getStudents() {
+        return students;
+    }
+
+    public void setStudents(List<Student> students) {
+        this.students = students;
+    }
 }

--- a/src/main/java/com/example/dorm/repository/BuildingRepository.java
+++ b/src/main/java/com/example/dorm/repository/BuildingRepository.java
@@ -1,0 +1,17 @@
+package com.example.dorm.repository;
+
+import com.example.dorm.model.Building;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BuildingRepository extends JpaRepository<Building, Long> {
+    Optional<Building> findByCodeIgnoreCase(String code);
+
+    boolean existsByCodeIgnoreCase(String code);
+
+    List<Building> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/example/dorm/repository/StudentRepository.java
+++ b/src/main/java/com/example/dorm/repository/StudentRepository.java
@@ -1,10 +1,10 @@
 package com.example.dorm.repository;
 
 import com.example.dorm.model.Student;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -13,6 +13,8 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
     List<Student> findByNameIgnoreCase(String name);
     List<Student> findByRoom_Id(Long roomId);
     long countByRoom_Id(Long roomId);
+    long countByRoomIsNotNull();
+    long countByRoom_Building_Id(Long buildingId);
 
     Optional<Student> findByCode(String code);
 

--- a/src/main/java/com/example/dorm/repository/UserRepository.java
+++ b/src/main/java/com/example/dorm/repository/UserRepository.java
@@ -1,8 +1,11 @@
 package com.example.dorm.repository;
 
+import com.example.dorm.model.RoleName;
 import com.example.dorm.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
+    List<User> findAllByRoles_Name(RoleName roleName);
 }

--- a/src/main/java/com/example/dorm/service/BuildingService.java
+++ b/src/main/java/com/example/dorm/service/BuildingService.java
@@ -1,0 +1,121 @@
+package com.example.dorm.service;
+
+import com.example.dorm.dto.BuildingSummary;
+import com.example.dorm.model.Building;
+import com.example.dorm.repository.BuildingRepository;
+import com.example.dorm.repository.RoomRepository;
+import com.example.dorm.repository.StudentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class BuildingService {
+
+    private final BuildingRepository buildingRepository;
+    private final RoomRepository roomRepository;
+    private final StudentRepository studentRepository;
+
+    public BuildingService(BuildingRepository buildingRepository,
+                           RoomRepository roomRepository,
+                           StudentRepository studentRepository) {
+        this.buildingRepository = buildingRepository;
+        this.roomRepository = roomRepository;
+        this.studentRepository = studentRepository;
+    }
+
+    public List<Building> getAllBuildings() {
+        return buildingRepository.findAllByOrderByNameAsc();
+    }
+
+    public Building createBuilding(Building building) {
+        String normalizedCode = normalizeCode(building.getCode());
+        ensureUniqueCode(normalizedCode, null);
+
+        building.setCode(normalizedCode);
+        building.setName(normalizeName(building.getName()));
+        building.setAddress(normalizeNullable(building.getAddress()));
+        building.setDescription(normalizeNullable(building.getDescription()));
+        building.setTotalFloors(normalizeFloor(building.getTotalFloors()));
+        return buildingRepository.save(building);
+    }
+
+    public Building updateBuilding(Long id, Building building) {
+        Building existing = getRequiredBuilding(id);
+
+        String normalizedCode = normalizeCode(building.getCode());
+        ensureUniqueCode(normalizedCode, id);
+
+        existing.setCode(normalizedCode);
+        existing.setName(normalizeName(building.getName()));
+        existing.setAddress(normalizeNullable(building.getAddress()));
+        existing.setDescription(normalizeNullable(building.getDescription()));
+        existing.setTotalFloors(normalizeFloor(building.getTotalFloors()));
+        return buildingRepository.save(existing);
+    }
+
+    public void deleteBuilding(Long id) {
+        if (roomRepository.existsByBuilding_Id(id)) {
+            throw new IllegalStateException("Không thể xóa tòa nhà khi vẫn còn phòng trực thuộc");
+        }
+        buildingRepository.deleteById(id);
+    }
+
+    public Building getRequiredBuilding(Long id) {
+        return buildingRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy tòa nhà với ID: " + id));
+    }
+
+    public List<BuildingSummary> getBuildingSummaries() {
+        return getAllBuildings().stream()
+                .map(building -> {
+                    int roomCount = roomRepository.countByBuilding_Id(building.getId());
+                    long capacity = roomRepository.sumCapacityByBuilding(building.getId());
+                    long occupied = studentRepository.countByRoom_Building_Id(building.getId());
+                    return new BuildingSummary(building, roomCount, capacity, occupied);
+                })
+                .sorted(Comparator.comparing(summary -> summary.name().toLowerCase()))
+                .toList();
+    }
+
+    private void ensureUniqueCode(String code, Long currentId) {
+        buildingRepository.findByCodeIgnoreCase(code)
+                .filter(existing -> currentId == null || !existing.getId().equals(currentId))
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("Mã tòa nhà đã tồn tại");
+                });
+    }
+
+    private String normalizeCode(String code) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("Mã tòa nhà không được để trống");
+        }
+        return code.trim().toUpperCase();
+    }
+
+    private String normalizeName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Tên tòa nhà không được để trống");
+        }
+        return name.trim();
+    }
+
+    private String normalizeNullable(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private Integer normalizeFloor(Integer totalFloors) {
+        if (totalFloors == null) {
+            return null;
+        }
+        if (totalFloors < 0) {
+            throw new IllegalArgumentException("Số tầng phải lớn hơn hoặc bằng 0");
+        }
+        return totalFloors;
+    }
+}

--- a/src/main/java/com/example/dorm/service/FeeService.java
+++ b/src/main/java/com/example/dorm/service/FeeService.java
@@ -59,6 +59,10 @@ public class FeeService {
         return feeRepository.findByContract_Student_IdAndPaymentStatus(studentId, PaymentStatus.UNPAID);
     }
 
+    public List<Fee> getAllFees() {
+        return feeRepository.findAll();
+    }
+
     public Page<Fee> searchFees(String search, Pageable pageable) {
         if (search == null || search.trim().isEmpty()) {
             return feeRepository.findAll(pageable);

--- a/src/main/java/com/example/dorm/service/MaintenanceRequestService.java
+++ b/src/main/java/com/example/dorm/service/MaintenanceRequestService.java
@@ -116,6 +116,31 @@ public class MaintenanceRequestService {
         return maintenanceRequestRepository.save(request);
     }
 
+    public MaintenanceRequest assignHandler(Long id, User handler) {
+        if (handler == null) {
+            throw new IllegalArgumentException("Không tìm thấy nhân viên xử lý");
+        }
+        MaintenanceRequest request = getRequiredRequest(id);
+        request.setHandledBy(handler);
+        String status = request.getStatus();
+        if (status == null || status.isBlank() || "PENDING".equalsIgnoreCase(status)) {
+            request.setStatus("IN_PROGRESS");
+        }
+        request.setUpdatedAt(LocalDateTime.now());
+        return maintenanceRequestRepository.save(request);
+    }
+
+    public MaintenanceRequest unassignHandler(Long id) {
+        MaintenanceRequest request = getRequiredRequest(id);
+        request.setHandledBy(null);
+        String status = request.getStatus();
+        if (!"COMPLETED".equalsIgnoreCase(status) && !"REJECTED".equalsIgnoreCase(status)) {
+            request.setStatus("PENDING");
+        }
+        request.setUpdatedAt(LocalDateTime.now());
+        return maintenanceRequestRepository.save(request);
+    }
+
     public long countAllRequests() {
         return maintenanceRequestRepository.count();
     }

--- a/src/main/java/com/example/dorm/service/UserService.java
+++ b/src/main/java/com/example/dorm/service/UserService.java
@@ -72,6 +72,18 @@ public class UserService {
                 .collect(Collectors.toList());
     }
 
+    public List<User> findUsersByRole(RoleName roleName) {
+        return userRepository.findAllByRoles_Name(roleName).stream()
+                .sorted(Comparator.comparing(user -> {
+                    String display = user.getFullName();
+                    if (display == null || display.isBlank()) {
+                        display = user.getUsername();
+                    }
+                    return display.toLowerCase();
+                }))
+                .collect(Collectors.toList());
+    }
+
     public boolean hasRole(User user, RoleName roleName) {
         return user.getRoles().stream()
                 .anyMatch(role -> role.getName() == roleName);

--- a/src/main/resources/database.sql
+++ b/src/main/resources/database.sql
@@ -26,6 +26,18 @@ CREATE TABLE student (
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- ============================================
+-- TABLE: BUILDING
+-- ============================================
+CREATE TABLE building (
+                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                          code VARCHAR(50) UNIQUE NOT NULL,
+                          name VARCHAR(255) NOT NULL,
+                          address VARCHAR(255),
+                          description TEXT,
+                          total_floors INT
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================
 -- TABLE: ROOM
 -- ============================================
 CREATE TABLE room (
@@ -33,7 +45,9 @@ CREATE TABLE room (
                       number    VARCHAR(50) UNIQUE NOT NULL,
                       type      VARCHAR(50),
                       capacity  INT NOT NULL,
-                      price     DECIMAL(10,2) DEFAULT 0.00 -- Suggest: Add CHECK (capacity > 0) if supported
+                      price     DECIMAL(10,2) DEFAULT 0.00,
+                      building_id BIGINT,
+                      CONSTRAINT fk_room_building FOREIGN KEY (building_id) REFERENCES building(id) ON DELETE SET NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- ============================================
@@ -111,9 +125,13 @@ CREATE TABLE maintenance_request (
                                      request_type VARCHAR(50),
                                      desired_room_number VARCHAR(50),
                                      status VARCHAR(50),
+                                     resolution_notes TEXT,
+                                     handled_by_id BIGINT,
                                      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                                     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                                      FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE,
-                                     FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE SET NULL
+                                     FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE SET NULL,
+                                     FOREIGN KEY (handled_by_id) REFERENCES users(id) ON DELETE SET NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- ============================================
@@ -193,12 +211,17 @@ INSERT INTO student (code, name, dob, gender, phone, address, email, department,
 -- ============================================
 -- SAMPLE DATA: ROOM
 -- ============================================
-INSERT INTO room (number, type, capacity, price) VALUES
-                                                     ('101', 'Phòng tám', 8, 1200000.00),
-                                                     ('102', 'Phòng tám', 8, 1200000.00),
-                                                     ('201', 'Phòng bốn', 4, 2000000.00),
-                                                     ('202', 'Phòng bốn', 4, 2000000.00),
-                                                     ('301', 'Phòng đôi', 2, 2500000.00);
+-- Danh sách tòa nhà mẫu
+INSERT INTO building (code, name, address, description, total_floors) VALUES
+                                                                         ('A', 'Tòa A', 'Khuôn viên chính', 'Khu dành cho sinh viên năm nhất', 6),
+                                                                         ('B', 'Tòa B', 'Khuôn viên chính', 'Khu tiêu chuẩn dành cho sinh viên năm hai', 5);
+
+INSERT INTO room (number, type, capacity, price, building_id) VALUES
+                                                                  ('101', 'Phòng tám', 8, 1200000.00, (SELECT id FROM building WHERE code = 'A')),
+                                                                  ('102', 'Phòng tám', 8, 1200000.00, (SELECT id FROM building WHERE code = 'A')),
+                                                                  ('201', 'Phòng bốn', 4, 2000000.00, (SELECT id FROM building WHERE code = 'B')),
+                                                                  ('202', 'Phòng bốn', 4, 2000000.00, (SELECT id FROM building WHERE code = 'B')),
+                                                                  ('301', 'Phòng đôi', 2, 2500000.00, (SELECT id FROM building WHERE code = 'B'));
 
 -- ============================================
 -- SAMPLE DATA: CONTRACT
@@ -213,12 +236,12 @@ INSERT INTO contract (student_id, room_id, start_date, end_date, status) VALUES
 -- ============================================
 -- SAMPLE DATA: MAINTENANCE REQUEST
 -- ============================================
-INSERT INTO maintenance_request (student_id, room_id, description, request_type, desired_room_number, status)
+INSERT INTO maintenance_request (student_id, room_id, description, request_type, desired_room_number, status, handled_by_id, resolution_notes)
 VALUES
     ((SELECT id FROM student WHERE code = 'SV01'), (SELECT id FROM room WHERE number = '101'),
-     'Đèn phòng bị hỏng, cần thay mới', 'MAINTENANCE', NULL, 'PENDING'),
+     'Đèn phòng bị hỏng, cần thay mới', 'MAINTENANCE', NULL, 'PENDING', NULL, NULL),
     ((SELECT id FROM student WHERE code = 'SV02'), (SELECT id FROM room WHERE number = '102'),
-     'Xin chuyển sang phòng 201 để học nhóm', 'ROOM_TRANSFER', '201', 'IN_PROGRESS');
+     'Xin chuyển sang phòng 201 để học nhóm', 'ROOM_TRANSFER', '201', 'IN_PROGRESS', (SELECT id FROM users WHERE username = 'staff'), 'Đang liên hệ bố trí phòng phù hợp');
 
 -- ============================================
 -- SAMPLE DATA: DORM REGISTRATION REQUEST

--- a/src/main/resources/templates/buildings/form.html
+++ b/src/main/resources/templates/buildings/form.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="vi" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${isEdit} ? 'Cập nhật tòa nhà' : 'Thêm tòa nhà'">Thêm tòa nhà</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="fragments/sidebar :: sidebar"></div>
+<div class="content-with-sidebar">
+    <div class="form-container">
+        <h2 th:text="${isEdit} ? 'Cập nhật tòa nhà' : 'Thêm tòa nhà'"></h2>
+        <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+        <form th:action="${isEdit} ? @{/buildings/{id}(id=${building.id})} : @{/buildings}"
+              th:object="${building}" method="post">
+            <div class="form-group">
+                <label for="code">Mã tòa</label>
+                <input type="text" id="code" th:field="*{code}" maxlength="50" required>
+            </div>
+            <div class="form-group">
+                <label for="name">Tên tòa</label>
+                <input type="text" id="name" th:field="*{name}" required>
+            </div>
+            <div class="form-group">
+                <label for="address">Địa chỉ</label>
+                <input type="text" id="address" th:field="*{address}">
+            </div>
+            <div class="form-group">
+                <label for="totalFloors">Số tầng</label>
+                <input type="number" id="totalFloors" th:field="*{totalFloors}" min="0">
+            </div>
+            <div class="form-group">
+                <label for="description">Mô tả</label>
+                <textarea id="description" th:field="*{description}" rows="4"
+                          placeholder="Ghi chú về vị trí, tiện ích, khu vực..."></textarea>
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="button btn-save">Lưu</button>
+                <a th:href="@{/buildings}" class="button btn-cancel">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/buildings/list.html
+++ b/src/main/resources/templates/buildings/list.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="vi" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Quản lý tòa nhà</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="fragments/sidebar :: sidebar"></div>
+<div class="content-with-sidebar">
+    <div class="container">
+        <h2>Danh sách tòa nhà</h2>
+        <div th:replace="~{fragments/header :: popup}"></div>
+        <div class="toolbar">
+            <a th:href="@{/buildings/new}" class="button btn-add"><i class="fas fa-plus"></i> Thêm tòa nhà</a>
+        </div>
+        <div class="responsive-table">
+            <table>
+                <thead>
+                <tr>
+                    <th>Mã tòa</th>
+                    <th>Tên tòa</th>
+                    <th>Địa chỉ</th>
+                    <th>Số tầng</th>
+                    <th>Số phòng</th>
+                    <th>Tổng sức chứa</th>
+                    <th>Đang ở</th>
+                    <th>Tỉ lệ lấp đầy</th>
+                    <th>Thao tác</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="summary : ${buildingSummaries}">
+                    <td th:text="${summary.code()}"></td>
+                    <td th:text="${summary.name()}"></td>
+                    <td th:text="${summary.address() != null ? summary.address() : 'Chưa cập nhật'}"></td>
+                    <td th:text="${summary.totalFloors() != null ? summary.totalFloors() : '-'}"></td>
+                    <td th:text="${summary.roomCount()}"></td>
+                    <td th:text="${summary.capacity()}"></td>
+                    <td th:text="${summary.occupiedBeds()}"></td>
+                    <td>
+                        <span th:text="${#numbers.formatDecimal(summary.occupancyRate(), 0, 2) + '%'}"
+                              th:class="${summary.occupancyRate() >= 90 ? 'badge badge-danger' : (summary.occupancyRate() >= 70 ? 'badge badge-warning' : 'badge badge-success')}">
+                        </span>
+                    </td>
+                    <td class="action-icons">
+                        <a th:href="@{/buildings/{id}/edit(id=${summary.id()})}" class="edit" title="Chỉnh sửa"><i class="fas fa-edit"></i></a>
+                        <a th:href="@{/buildings/{id}/delete(id=${summary.id()})}" class="delete" title="Xóa" onclick="return confirm('Bạn có chắc muốn xóa tòa này?')"><i class="fas fa-trash"></i></a>
+                    </td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(buildingSummaries)}">
+                    <td colspan="9">Chưa có tòa nhà nào được khai báo.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -26,6 +26,10 @@
                     <i class="fas fa-bed"></i>
                     <span>Phòng</span>
                 </a>
+                <a th:href="@{/buildings}" class="sidebar-link">
+                    <i class="fas fa-building"></i>
+                    <span>Tòa nhà</span>
+                </a>
                 <a th:href="@{/contracts}" class="sidebar-link">
                     <i class="fas fa-file-contract"></i>
                     <span>Hợp đồng</span>
@@ -37,6 +41,10 @@
                 <a th:href="@{/users}" class="sidebar-link">
                     <i class="fas fa-user-shield"></i>
                     <span>Tài khoản & phân quyền</span>
+                </a>
+                <a th:href="@{/reports}" class="sidebar-link">
+                    <i class="fas fa-chart-line"></i>
+                    <span>Báo cáo & thống kê</span>
                 </a>
             </nav>
         </div>

--- a/src/main/resources/templates/maintenance/detail.html
+++ b/src/main/resources/templates/maintenance/detail.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <title>Chi tiết yêu cầu</title>
@@ -54,7 +54,7 @@
                           th:text="${request.status}"></span>
                 </p>
                 <p><strong>Người phụ trách:</strong>
-                    <span th:if="${request.handledBy != null}" th:text="${request.handledBy.username}"></span>
+                    <span th:if="${request.handledBy != null}" th:text="${request.handledBy.fullName != null ? request.handledBy.fullName : request.handledBy.username}"></span>
                     <span th:if="${request.handledBy == null}">Chưa phân công</span>
                 </p>
                 <p><strong>Liên hệ:</strong>
@@ -92,6 +92,45 @@
                 </div>
                 <button class="button btn-add" type="submit">Lưu thay đổi</button>
             </form>
+        </div>
+        <div class="detail-grid">
+            <div class="detail-card" sec:authorize="hasRole('ADMIN')">
+                <h3>Phân công nhân viên</h3>
+                <form th:action="@{'/maintenance/' + ${request.id} + '/assign'}" method="post" class="status-form">
+                    <div class="form-group-full">
+                        <label for="assigneeId">Chọn nhân viên hỗ trợ</label>
+                        <select id="assigneeId" name="assigneeId" required>
+                            <option value="">--Chọn nhân viên--</option>
+                            <option th:each="staff : ${staffMembers}"
+                                    th:value="${staff.id}"
+                                    th:text="${staff.fullName != null ? staff.fullName + ' (' + staff.username + ')' : staff.username}"
+                                    th:selected="${request.handledBy != null and staff.id.equals(request.handledBy.id)}"></option>
+                        </select>
+                    </div>
+                    <div class="form-actions">
+                        <button class="button btn-save" type="submit">Phân công</button>
+                        <button class="button btn-cancel" type="submit" th:formaction="@{'/maintenance/' + ${request.id} + '/unassign'}"
+                                th:disabled="${request.handledBy == null}"
+                                onclick="return confirm('Xác nhận hủy phân công yêu cầu này?')">Hủy phân công</button>
+                    </div>
+                </form>
+            </div>
+            <div class="detail-card" sec:authorize="hasRole('STAFF')">
+                <h3>Tiếp nhận yêu cầu</h3>
+                <p th:if="${request.handledBy == null}">Yêu cầu chưa có người xử lý, bạn có thể nhấn nút bên dưới để tiếp nhận.</p>
+                <p th:if="${request.handledBy != null}" th:text="${'Đang được xử lý bởi: ' + (request.handledBy.fullName != null ? request.handledBy.fullName : request.handledBy.username)}"></p>
+                <div class="form-actions">
+                    <form th:if="${request.handledBy == null or request.handledBy.username == #authentication?.name}" th:action="@{'/maintenance/' + ${request.id} + '/accept'}" method="post">
+                        <button class="button btn-save" type="submit"
+                                th:disabled="${request.handledBy != null and request.handledBy.username == #authentication?.name}">
+                            Tôi sẽ xử lý
+                        </button>
+                    </form>
+                    <form th:if="${request.handledBy != null and request.handledBy.username == #authentication?.name}" th:action="@{'/maintenance/' + ${request.id} + '/unassign'}" method="post">
+                        <button class="button btn-cancel" type="submit" onclick="return confirm('Bạn chắc chắn muốn hủy tiếp nhận yêu cầu này?')">Hủy tiếp nhận</button>
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/reports/overview.html
+++ b/src/main/resources/templates/reports/overview.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="vi" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Báo cáo &amp; thống kê</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="fragments/sidebar :: sidebar"></div>
+<div class="content-with-sidebar">
+    <div class="container">
+        <h2>Báo cáo &amp; thống kê</h2>
+        <p class="text-muted">Tổng hợp số liệu vận hành ký túc xá giúp quản trị viên theo dõi tình trạng sử dụng và dịch vụ hỗ trợ.</p>
+        <div class="stat-grid">
+            <div class="stat-card">
+                <span class="stat-title">Tổng sinh viên</span>
+                <span class="stat-value" th:text="${studentCount}"></span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Số tòa đang quản lý</span>
+                <span class="stat-value" th:text="${buildingCount}"></span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Tổng sức chứa</span>
+                <span class="stat-value" th:text="${totalCapacity}"></span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Giường đang sử dụng</span>
+                <span class="stat-value" th:text="${occupiedBeds}"></span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Giường còn trống</span>
+                <span class="stat-value" th:text="${availableBeds}"></span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Tỷ lệ lấp đầy</span>
+                <span class="stat-value" th:text="${#numbers.formatDecimal(occupancyRate, 0, 2)} + '%'">0%</span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Yêu cầu hỗ trợ</span>
+                <span class="stat-value" th:text="${totalRequests}"></span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Doanh thu đã ghi nhận</span>
+                <span class="stat-value" th:text="${#numbers.formatDecimal(totalRevenue, 0, 0)} + ' ₫'"></span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-title">Cần thu thêm</span>
+                <span class="stat-value" th:text="${#numbers.formatDecimal(outstandingRevenue, 0, 0)} + ' ₫'"></span>
+            </div>
+        </div>
+
+        <h3>Hiệu suất theo tòa</h3>
+        <div class="responsive-table">
+            <table>
+                <thead>
+                <tr>
+                    <th>Tòa</th>
+                    <th>Tên tòa</th>
+                    <th>Số phòng</th>
+                    <th>Tổng sức chứa</th>
+                    <th>Đang ở</th>
+                    <th>Tỷ lệ lấp đầy</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="summary : ${buildingSummaries}">
+                    <td th:text="${summary.code()}"></td>
+                    <td th:text="${summary.name()}"></td>
+                    <td th:text="${summary.roomCount()}"></td>
+                    <td th:text="${summary.capacity()}"></td>
+                    <td th:text="${summary.occupiedBeds()}"></td>
+                    <td>
+                        <span class="badge"
+                              th:classappend="${summary.occupancyRate() >= 90} ? ' badge-danger' : (${summary.occupancyRate() >= 70} ? ' badge-warning' : ' badge-success')"
+                              th:text="${#numbers.formatDecimal(summary.occupancyRate(), 0, 2)} + '%'">
+                        </span>
+                    </td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(buildingSummaries)}">
+                    <td colspan="6">Chưa có dữ liệu tòa nhà.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="detail-grid">
+            <div class="detail-card">
+                <h3>Trạng thái yêu cầu hỗ trợ</h3>
+                <ul class="status-list">
+                    <li th:each="entry : ${maintenanceSummary.entrySet()}"
+                        th:text="${entry.key} + ': ' + entry.value + ' yêu cầu'"></li>
+                    <li th:if="${#maps.isEmpty(maintenanceSummary)}">Chưa có yêu cầu nào.</li>
+                </ul>
+            </div>
+            <div class="detail-card">
+                <h3>Gợi ý</h3>
+                <p th:if="${occupancyRate >= 90}">
+                    Hầu hết các giường đã kín, hãy cân nhắc mở thêm phòng hoặc thông báo cho sinh viên về danh sách chờ.
+                </p>
+                <p th:if="${occupancyRate < 90 and occupancyRate >= 60}">
+                    Công suất sử dụng ổn định. Có thể triển khai thêm chương trình chăm sóc sinh viên để giữ mức lấp đầy.
+                </p>
+                <p th:if="${occupancyRate < 60}">
+                    Công suất đang thấp. Khuyến nghị rà soát lại chiến dịch tuyển sinh nội trú hoặc xem xét giảm giá ưu đãi.
+                </p>
+                <p th:if="${outstandingRevenue.compareTo(T(java.math.BigDecimal).ZERO) > 0}">
+                    Còn khoản phí chưa thu. Hãy gửi nhắc nhở thanh toán tới sinh viên để đảm bảo dòng tiền.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/rooms/detail.html
+++ b/src/main/resources/templates/rooms/detail.html
@@ -22,8 +22,16 @@
                 <td class="value" th:text="${room.number}"></td>
             </tr>
             <tr>
+                <td class="label">Tòa:</td>
+                <td class="value" th:text="${room.building != null ? room.building.code + ' - ' + room.building.name : 'N/A'}"></td>
+            </tr>
+            <tr>
                 <td class="label">Loại Phòng:</td>
                 <td class="value" th:text="${room.type}"></td>
+            </tr>
+            <tr>
+                <td class="label">Giá/Tháng:</td>
+                <td class="value" th:text="${T(java.lang.String).format('%,d', room.price).replace(',', '.')} + ' VNĐ'"></td>
             </tr>
             <tr>
                 <td class="label">Sức Chứa:</td>

--- a/src/main/resources/templates/rooms/form.html
+++ b/src/main/resources/templates/rooms/form.html
@@ -1,28 +1,49 @@
 <!DOCTYPE html>
-<html lang="vi" xmlns:th="http://www.thymeleaf.org">
+<html lang="vi" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <title th:text="${room.id} ? 'Sửa Phòng' : 'Thêm Phòng'">Thêm Phòng</title>
     <link rel="stylesheet" th:href="@{/css/style.css}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <script>
-        function updatePriceAndCapacity() {
-            var type = document.getElementById('type').value;
+        function updateDefaults() {
+            var type = document.getElementById('type');
             var priceInput = document.getElementById('price');
             var capacityInput = document.getElementById('capacity');
-            if (!type) {
-                priceInput.value = '';
-                capacityInput.value = '';
+            if (!type || !priceInput || !capacityInput) {
                 return;
             }
-            if (type === 'Phòng bốn') {
-                priceInput.value = 2000000;
+            var selectedType = type.value;
+            if (!selectedType) {
+                return;
+            }
+            if (selectedType === 'Phòng bốn') {
+                if (!priceInput.dataset.manual) {
+                    priceInput.value = 2000000;
+                }
                 capacityInput.value = 4;
-            } else if (type === 'Phòng tám') {
-                priceInput.value = 1200000;
+            } else if (selectedType === 'Phòng tám') {
+                if (!priceInput.dataset.manual) {
+                    priceInput.value = 1200000;
+                }
                 capacityInput.value = 8;
             }
         }
+
+        function markManualPrice() {
+            var priceInput = document.getElementById('price');
+            if (priceInput) {
+                priceInput.dataset.manual = 'true';
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', function () {
+            var priceInput = document.getElementById('price');
+            if (priceInput) {
+                priceInput.addEventListener('input', markManualPrice);
+            }
+            updateDefaults();
+        });
     </script>
 </head>
 <body>
@@ -31,38 +52,49 @@
 <div class="content-with-sidebar">
     <div class="form-container">
         <h2 th:text="${room.id} ? 'Sửa Phòng' : 'Thêm Phòng'"></h2>
+        <div th:if="${formError}" class="alert alert-danger" th:text="${formError}"></div>
+        <div th:if="${#lists.isEmpty(buildings)}" class="alert alert-warning">
+            Chưa có tòa nhà nào. Vui lòng <a th:href="@{/buildings/new}">thêm tòa nhà</a> trước khi tạo phòng.
+        </div>
         <form th:action="${room.id} ? @{/rooms/{id}(id=${room.id})} : @{/rooms}" th:object="${room}" method="post">
             <div class="form-group">
                 <label for="number">Số Phòng</label>
                 <input type="text" id="number" th:field="*{number}" required>
             </div>
             <div class="form-group">
+                <label for="buildingId">Thuộc tòa</label>
+                <select id="buildingId" name="buildingId" required>
+                    <option value="" th:selected="${selectedBuildingId == null}">--Chọn tòa nhà--</option>
+                    <option th:each="building : ${buildings}"
+                            th:value="${building.id}"
+                            th:text="${building.code + ' - ' + building.name}"
+                            th:selected="${selectedBuildingId != null and selectedBuildingId.equals(building.id)}"></option>
+                </select>
+            </div>
+            <div class="form-group">
                 <label for="type">Loại Phòng</label>
-                <select id="type" th:field="*{type}" onchange="updatePriceAndCapacity()" required>
+                <select id="type" th:field="*{type}" onchange="updateDefaults()" required>
                     <option value="">--Chọn loại phòng--</option>
                     <option value="Phòng bốn">Phòng bốn</option>
                     <option value="Phòng tám">Phòng tám</option>
+                    <option value="Phòng đôi">Phòng đôi</option>
                 </select>
             </div>
             <div class="form-group">
                 <label for="capacity">Sức Chứa</label>
-                <input type="number" id="capacity" th:field="*{capacity}" readonly required>
+                <input type="number" id="capacity" th:field="*{capacity}" min="1" required>
             </div>
             <div class="form-group">
-                <label for="price">Giá Phòng</label>
-                <input type="number" id="price" th:field="*{price}" readonly required>
+                <label for="price">Giá Phòng (VNĐ)</label>
+                <input type="number" id="price" th:field="*{price}" min="0" step="1000" required>
+                <small>Giá mặc định sẽ được gợi ý theo loại phòng, quản trị có thể điều chỉnh.</small>
             </div>
             <div class="form-actions">
-                <button type="submit" class="button btn-save">Lưu</button>
+                <button type="submit" class="button btn-save" th:disabled="${#lists.isEmpty(buildings)}">Lưu</button>
                 <a th:href="@{/rooms}" class="button btn-cancel">Hủy</a>
             </div>
         </form>
     </div>
 </div>
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        updatePriceAndCapacity();
-    });
-</script>
 </body>
 </html>

--- a/src/main/resources/templates/rooms/list.html
+++ b/src/main/resources/templates/rooms/list.html
@@ -13,10 +13,17 @@
         <div class="container">
         <h2>Danh Sách Phòng</h2>
         <div th:replace="~{fragments/header :: popup}"></div>
-        <div class="search-container">
+        <div class="search-container room-filter">
             <form th:action="@{/rooms}" method="get">
-                <input type="text" name="search" placeholder="Tìm kiếm phòng..." th:value="${search}">
-                <button type="submit">Tìm kiếm</button>
+                <input type="text" name="search" placeholder="Tìm kiếm phòng hoặc loại..." th:value="${search}">
+                <select name="buildingId">
+                    <option value="" th:selected="${selectedBuildingId == null}">Tất cả tòa</option>
+                    <option th:each="building : ${buildings}"
+                            th:value="${building.id}"
+                            th:text="${building.code + ' - ' + building.name}"
+                            th:selected="${selectedBuildingId != null and selectedBuildingId.equals(building.id)}"></option>
+                </select>
+                <button type="submit">Lọc</button>
             </form>
             <a th:href="@{/rooms/new}" class="button btn-add">Thêm Phòng</a>
         </div>
@@ -25,6 +32,7 @@
                 <tr>
                     <th>ID</th>
                     <th>Số Phòng</th>
+                    <th>Tòa</th>
                     <th>Loại Phòng</th>
                     <th>Sức Chứa</th>
                     <th>Đang Ở</th>
@@ -36,6 +44,7 @@
                 <tr th:each="room : ${roomsPage.content}" class="table-row">
                     <td th:text="${room.id}"></td>
                     <td th:text="${room.number}"></td>
+                    <td th:text="${room.building != null ? room.building.code : 'N/A'}"></td>
                     <td th:text="${room.type}"></td>
                     <td th:text="${room.capacity}"></td>
                     <td th:text="${occupancies[room.id]}"></td>
@@ -49,14 +58,14 @@
             </tbody>
         </table>
         <div class="pagination">
-            <a th:if="${roomsPage.number > 0}" th:href="@{/rooms(page=${roomsPage.number-1},size=${roomsPage.size},search=${search})}">Trước</a>
+            <a th:if="${roomsPage.number > 0}" th:href="@{/rooms(page=${roomsPage.number-1},size=${roomsPage.size},search=${search},buildingId=${selectedBuildingId})}">Trước</a>
             <span th:each="i : ${pageNumbers}">
-                <a th:href="@{/rooms(page=${i-1},size=${roomsPage.size},search=${search})}"
+                <a th:href="@{/rooms(page=${i-1},size=${roomsPage.size},search=${search},buildingId=${selectedBuildingId})}"
                    th:text="${i}"
                    th:classappend="${i-1 == roomsPage.number} ? 'current' : ''">
                 </a>
             </span>
-            <a th:if="${roomsPage.number + 1 < roomsPage.totalPages}" th:href="@{/rooms(page=${roomsPage.number+1},size=${roomsPage.size},search=${search})}">Sau</a>
+            <a th:if="${roomsPage.number + 1 < roomsPage.totalPages}" th:href="@{/rooms(page=${roomsPage.number+1},size=${roomsPage.size},search=${search},buildingId=${selectedBuildingId})}">Sau</a>
         </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce building management with persistence, validation, and dedicated admin views, and link rooms to buildings
- allow administrators to control room pricing, filter rooms by building, and update the database schema/sample data accordingly
- enable maintenance request assignment workflows for admins/staff and add an admin-focused reports dashboard summarizing occupancy, fees, and support trends

## Testing
- `mvn -q test` *(fails: remote parent POM download blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdbc6d2188326b96d04653982adc1