### PR TITLE
Add room-wide fee support and enhance fee reports

### DIFF
--- a/src/main/java/com/example/dorm/config/DemoDataInitializer.java
+++ b/src/main/java/com/example/dorm/config/DemoDataInitializer.java
@@ -269,6 +269,15 @@ public class DemoDataInitializer implements ApplicationRunner {
                     boolean changed = false;
                     if (existing.getAmount() == null || existing.getAmount().compareTo(amount) != 0) {
                         existing.setAmount(amount);
+                        existing.setTotalAmount(amount);
+                        changed = true;
+                    }
+                    if (existing.getScope() == null) {
+                        existing.setScope(FeeScope.INDIVIDUAL);
+                        changed = true;
+                    }
+                    if (existing.getTotalAmount() == null) {
+                        existing.setTotalAmount(amount);
                         changed = true;
                     }
                     if (!status.equals(existing.getPaymentStatus())) {
@@ -282,6 +291,8 @@ public class DemoDataInitializer implements ApplicationRunner {
                     fee.setContract(contract);
                     fee.setType(type);
                     fee.setAmount(amount);
+                    fee.setTotalAmount(amount);
+                    fee.setScope(FeeScope.INDIVIDUAL);
                     fee.setDueDate(dueDate);
                     fee.setPaymentStatus(status);
                     return feeRepository.save(fee);

--- a/src/main/java/com/example/dorm/dto/FeeScopeSummary.java
+++ b/src/main/java/com/example/dorm/dto/FeeScopeSummary.java
@@ -1,0 +1,15 @@
+package com.example.dorm.dto;
+
+import com.example.dorm.model.FeeScope;
+
+import java.math.BigDecimal;
+
+public record FeeScopeSummary(FeeScope scope,
+                              long feeCount,
+                              BigDecimal totalAmount,
+                              BigDecimal unpaidAmount) {
+
+    public String displayName() {
+        return scope == FeeScope.ROOM ? "Cả phòng" : "Cá nhân";
+    }
+}

--- a/src/main/java/com/example/dorm/dto/FeeTypeSummary.java
+++ b/src/main/java/com/example/dorm/dto/FeeTypeSummary.java
@@ -1,0 +1,22 @@
+package com.example.dorm.dto;
+
+import com.example.dorm.model.FeeType;
+
+import java.math.BigDecimal;
+
+public record FeeTypeSummary(FeeType type,
+                             long feeCount,
+                             BigDecimal totalAmount,
+                             long unpaidCount,
+                             BigDecimal unpaidAmount) {
+
+    public String displayName() {
+        return switch (type) {
+            case RENT -> "Tiền phòng";
+            case ELECTRICITY -> "Tiền điện";
+            case WATER -> "Tiền nước";
+            case MAINTENANCE -> "Bảo trì";
+            case CLEANING -> "Dọn dẹp";
+        };
+    }
+}

--- a/src/main/java/com/example/dorm/model/Fee.java
+++ b/src/main/java/com/example/dorm/model/Fee.java
@@ -17,7 +17,22 @@ public class Fee {
     @Enumerated(EnumType.STRING)
     private FeeType type;
 
+    @Enumerated(EnumType.STRING)
+    private FeeScope scope = FeeScope.INDIVIDUAL;
+
+    /**
+     * Amount that the student needs to pay. For room-scoped fees this is the
+     * distributed amount assigned to the contract.
+     */
     private BigDecimal amount;
+
+    /**
+     * The total amount of the fee before distribution. Equals {@link #amount}
+     * for individual fees.
+     */
+    private BigDecimal totalAmount;
+
+    private String groupCode;
     private LocalDate dueDate;
 
     @Enumerated(EnumType.STRING)
@@ -30,8 +45,14 @@ public class Fee {
     public void setContract(Contract contract) { this.contract = contract; }
     public FeeType getType() { return type; }
     public void setType(FeeType type) { this.type = type; }
+    public FeeScope getScope() { return scope; }
+    public void setScope(FeeScope scope) { this.scope = scope; }
     public BigDecimal getAmount() { return amount; }
     public void setAmount(BigDecimal amount) { this.amount = amount; }
+    public BigDecimal getTotalAmount() { return totalAmount; }
+    public void setTotalAmount(BigDecimal totalAmount) { this.totalAmount = totalAmount; }
+    public String getGroupCode() { return groupCode; }
+    public void setGroupCode(String groupCode) { this.groupCode = groupCode; }
     public LocalDate getDueDate() { return dueDate; }
     public void setDueDate(LocalDate dueDate) { this.dueDate = dueDate; }
     public PaymentStatus getPaymentStatus() { return paymentStatus; }

--- a/src/main/java/com/example/dorm/model/FeeScope.java
+++ b/src/main/java/com/example/dorm/model/FeeScope.java
@@ -1,0 +1,6 @@
+package com.example.dorm.model;
+
+public enum FeeScope {
+    INDIVIDUAL,
+    ROOM
+}

--- a/src/main/java/com/example/dorm/repository/FeeRepository.java
+++ b/src/main/java/com/example/dorm/repository/FeeRepository.java
@@ -46,4 +46,6 @@ public interface FeeRepository extends JpaRepository<Fee, Long> {
                                                 Pageable pageable);
 
     Optional<Fee> findByContract_IdAndTypeAndDueDate(Long contractId, FeeType type, LocalDate dueDate);
+
+    java.util.List<Fee> findByGroupCode(String groupCode);
 }

--- a/src/main/java/com/example/dorm/service/FeeService.java
+++ b/src/main/java/com/example/dorm/service/FeeService.java
@@ -1,23 +1,38 @@
 package com.example.dorm.service;
 
+import com.example.dorm.model.Contract;
 import com.example.dorm.model.Fee;
+import com.example.dorm.model.FeeScope;
 import com.example.dorm.model.FeeType;
 import com.example.dorm.model.PaymentStatus;
+import com.example.dorm.repository.ContractRepository;
 import com.example.dorm.repository.FeeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class FeeService {
 
     private final FeeRepository feeRepository;
+    private final ContractRepository contractRepository;
 
-    public FeeService(FeeRepository feeRepository) {
+    public FeeService(FeeRepository feeRepository, ContractRepository contractRepository) {
         this.feeRepository = feeRepository;
+        this.contractRepository = contractRepository;
     }
 
     public Page<Fee> getAllFees(Pageable pageable) {
@@ -32,19 +47,30 @@ public class FeeService {
         return getFee(id).orElseThrow(() -> new IllegalArgumentException("Fee not found"));
     }
 
-    public Fee createFee(Fee fee) {
-        return feeRepository.save(fee);
+    public void createFee(Fee fee, BigDecimal totalAmount) {
+        FeeScope scope = fee.getScope() != null ? fee.getScope() : FeeScope.INDIVIDUAL;
+        if (scope == FeeScope.ROOM) {
+            distributeRoomFee(fee, normalizeAmount(totalAmount));
+        } else {
+            persistIndividualFee(fee, normalizeAmount(totalAmount));
+        }
     }
 
-    public Fee updateFee(Long id, Fee fee) {
-        Fee existing = feeRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Fee not found"));
-        existing.setAmount(fee.getAmount());
-        existing.setContract(fee.getContract());
-        existing.setType(fee.getType());
-        existing.setDueDate(fee.getDueDate());
-        existing.setPaymentStatus(fee.getPaymentStatus());
-        return feeRepository.save(existing);
+    public void updateFee(Long id, Fee fee, BigDecimal totalAmount) {
+        Fee existing = getRequiredFee(id);
+        FeeScope newScope = fee.getScope() != null ? fee.getScope() : FeeScope.INDIVIDUAL;
+        FeeScope currentScope = existing.getScope() != null ? existing.getScope() : FeeScope.INDIVIDUAL;
+        BigDecimal normalizedTotal = normalizeAmount(totalAmount);
+
+        if (currentScope == FeeScope.ROOM && newScope == FeeScope.ROOM) {
+            updateRoomFeeGroup(existing, fee, normalizedTotal);
+        } else if (currentScope == FeeScope.ROOM && newScope == FeeScope.INDIVIDUAL) {
+            convertRoomFeeToIndividual(existing, fee, normalizedTotal);
+        } else if (currentScope == FeeScope.INDIVIDUAL && newScope == FeeScope.ROOM) {
+            convertIndividualFeeToRoom(existing, fee, normalizedTotal);
+        } else {
+            updateIndividual(existing, fee, normalizedTotal);
+        }
     }
 
     public void deleteFee(Long id) {
@@ -85,5 +111,170 @@ public class FeeService {
 
     public long countFees() {
         return feeRepository.count();
+    }
+
+    private void persistIndividualFee(Fee fee, BigDecimal totalAmount) {
+        Contract contract = getRequiredContract(fee);
+        fee.setContract(contract);
+        fee.setScope(FeeScope.INDIVIDUAL);
+        fee.setAmount(totalAmount);
+        fee.setTotalAmount(totalAmount);
+        fee.setGroupCode(null);
+        feeRepository.save(fee);
+    }
+
+    private void distributeRoomFee(Fee template, BigDecimal totalAmount) {
+        Contract baseContract = getRequiredContract(template);
+        List<Contract> roomContracts = contractRepository.findByRoom_Id(baseContract.getRoom().getId());
+        if (roomContracts.isEmpty()) {
+            throw new IllegalStateException("Phòng chưa có thành viên để phân bổ phí.");
+        }
+
+        String groupCode = template.getGroupCode();
+        if (groupCode == null || groupCode.isBlank()) {
+            groupCode = UUID.randomUUID().toString();
+        }
+
+        Map<Long, Fee> existing = Collections.emptyMap();
+        distributeToContracts(template, totalAmount, groupCode, roomContracts, existing);
+    }
+
+    private void updateRoomFeeGroup(Fee existing, Fee template, BigDecimal totalAmount) {
+        String groupCode = existing.getGroupCode();
+        if (groupCode == null || groupCode.isBlank()) {
+            groupCode = UUID.randomUUID().toString();
+        }
+
+        List<Fee> groupMembers = feeRepository.findByGroupCode(groupCode);
+        if (groupMembers.isEmpty()) {
+            groupMembers = List.of(existing);
+        }
+
+        Contract baseContract = existing.getContract();
+        if (template.getContract() != null && template.getContract().getId() != null) {
+            baseContract = getRequiredContract(template);
+        }
+        List<Contract> roomContracts = contractRepository.findByRoom_Id(baseContract.getRoom().getId());
+        if (roomContracts.isEmpty()) {
+            throw new IllegalStateException("Phòng chưa có thành viên để phân bổ phí.");
+        }
+
+        Set<Long> contractIds = roomContracts.stream()
+                .map(Contract::getId)
+                .collect(Collectors.toSet());
+
+        List<Fee> removable = groupMembers.stream()
+                .filter(f -> f.getContract() == null || !contractIds.contains(f.getContract().getId()))
+                .collect(Collectors.toList());
+        if (!removable.isEmpty()) {
+            feeRepository.deleteAll(removable);
+        }
+
+        Map<Long, Fee> existingByContract = groupMembers.stream()
+                .filter(f -> f.getContract() != null && contractIds.contains(f.getContract().getId()))
+                .collect(Collectors.toMap(f -> f.getContract().getId(), f -> f));
+
+        distributeToContracts(template, totalAmount, groupCode, roomContracts, existingByContract);
+    }
+
+    private void convertRoomFeeToIndividual(Fee existing, Fee template, BigDecimal totalAmount) {
+        String groupCode = existing.getGroupCode();
+        if (groupCode != null && !groupCode.isBlank()) {
+            List<Fee> groupMembers = feeRepository.findByGroupCode(groupCode);
+            groupMembers.stream()
+                    .filter(member -> !Objects.equals(member.getId(), existing.getId()))
+                    .forEach(feeRepository::delete);
+        }
+
+        Contract contract = getRequiredContract(template);
+        existing.setContract(contract);
+        existing.setScope(FeeScope.INDIVIDUAL);
+        existing.setGroupCode(null);
+        existing.setType(template.getType());
+        existing.setDueDate(template.getDueDate());
+        existing.setPaymentStatus(template.getPaymentStatus());
+        existing.setAmount(totalAmount);
+        existing.setTotalAmount(totalAmount);
+        feeRepository.save(existing);
+    }
+
+    private void convertIndividualFeeToRoom(Fee existing, Fee template, BigDecimal totalAmount) {
+        feeRepository.delete(existing);
+        distributeRoomFee(template, totalAmount);
+    }
+
+    private void updateIndividual(Fee existing, Fee template, BigDecimal totalAmount) {
+        Contract contract = getRequiredContract(template);
+        existing.setContract(contract);
+        existing.setScope(FeeScope.INDIVIDUAL);
+        existing.setGroupCode(null);
+        existing.setType(template.getType());
+        existing.setDueDate(template.getDueDate());
+        existing.setPaymentStatus(template.getPaymentStatus());
+        existing.setAmount(totalAmount);
+        existing.setTotalAmount(totalAmount);
+        feeRepository.save(existing);
+    }
+
+    private void distributeToContracts(Fee template,
+                                       BigDecimal totalAmount,
+                                       String groupCode,
+                                       List<Contract> contracts,
+                                       Map<Long, Fee> existingByContract) {
+        int participantCount = contracts.size();
+        if (participantCount == 0) {
+            throw new IllegalStateException("Phòng chưa có thành viên để phân bổ phí.");
+        }
+
+        List<Contract> sortedContracts = contracts.stream()
+                .sorted(Comparator.comparing(Contract::getId))
+                .toList();
+
+        int scale = Math.max(totalAmount.scale(), 0);
+        BigDecimal divisor = BigDecimal.valueOf(participantCount);
+        BigDecimal baseShare = totalAmount.divide(divisor, scale, RoundingMode.DOWN);
+        BigDecimal allocated = baseShare.multiply(divisor);
+        BigDecimal remainder = totalAmount.subtract(allocated);
+        BigDecimal unit = BigDecimal.ONE.scaleByPowerOfTen(-scale);
+
+        List<Fee> toPersist = new ArrayList<>();
+        for (Contract contract : sortedContracts) {
+            Fee fee = existingByContract.getOrDefault(contract.getId(), new Fee());
+            fee.setContract(contract);
+            fee.setScope(FeeScope.ROOM);
+            fee.setGroupCode(groupCode);
+            fee.setType(template.getType());
+            fee.setDueDate(template.getDueDate());
+            fee.setPaymentStatus(template.getPaymentStatus());
+
+            BigDecimal share = baseShare;
+            if (remainder.compareTo(unit) >= 0) {
+                share = share.add(unit);
+                remainder = remainder.subtract(unit);
+            } else if (remainder.compareTo(BigDecimal.ZERO) > 0) {
+                share = share.add(remainder);
+                remainder = BigDecimal.ZERO;
+            }
+            fee.setAmount(share);
+            fee.setTotalAmount(totalAmount);
+            toPersist.add(fee);
+        }
+
+        feeRepository.saveAll(toPersist);
+    }
+
+    private Contract getRequiredContract(Fee fee) {
+        if (fee.getContract() == null || fee.getContract().getId() == null) {
+            throw new IllegalArgumentException("Cần chọn hợp đồng để tạo phí.");
+        }
+        return contractRepository.findById(fee.getContract().getId())
+                .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy hợp đồng với ID đã chọn."));
+    }
+
+    private BigDecimal normalizeAmount(BigDecimal amount) {
+        if (amount == null) {
+            return BigDecimal.ZERO;
+        }
+        return amount;
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -593,6 +593,14 @@ h2 {
     color: var(--danger-color);
 }
 
+.form-hint {
+    display: block;
+    margin-left: 120px;
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
 .form-group-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/src/main/resources/templates/fees/detail.html
+++ b/src/main/resources/templates/fees/detail.html
@@ -34,8 +34,16 @@
                 <td class="value" th:text="${fee.type}"></td>
             </tr>
             <tr>
+                <td class="label">Phạm Vi:</td>
+                <td class="value" th:text="${fee.scope == null ? 'Cá nhân' : (fee.scope.name() == 'ROOM' ? 'Cả phòng' : 'Cá nhân')}"></td>
+            </tr>
+            <tr>
                 <td class="label">Số Tiền:</td>
-                <td class="value" th:text="${T(java.lang.String).format('%,d', fee.amount.intValue()).replace(',', '.')}" ></td>
+                <td class="value" th:text="${T(java.lang.String).format('%,d', fee.amount.longValue()).replace(',', '.')}" ></td>
+            </tr>
+            <tr th:if="${fee.scope != null && fee.scope.name() == 'ROOM'}">
+                <td class="label">Tổng Phí:</td>
+                <td class="value" th:text="${fee.totalAmount != null ? T(java.lang.String).format('%,d', fee.totalAmount.longValue()).replace(',', '.') : ''}"></td>
             </tr>
             <tr>
                 <td class="label">Ngày Đáo Hạn:</td>

--- a/src/main/resources/templates/fees/form.html
+++ b/src/main/resources/templates/fees/form.html
@@ -31,10 +31,19 @@
                 </select>
             </div>
             <div class="form-group">
+                <label for="scope">Phạm vi áp dụng</label>
+                <select id="scope" th:field="*{scope}" required>
+                    <option th:value="${T(com.example.dorm.model.FeeScope).INDIVIDUAL}">Cá nhân</option>
+                    <option th:value="${T(com.example.dorm.model.FeeScope).ROOM}">Cả phòng</option>
+                </select>
+                <small class="form-hint">Chọn "Cả phòng" để hệ thống tự động chia đều số tiền cho từng thành viên trong phòng.</small>
+            </div>
+            <div class="form-group">
                 <label for="amount">Số Tiền</label>
                 <input type="text" id="amount" name="amountInput"
-                       th:value="${fee.amount != null ? T(java.lang.String).format('%,d', fee.amount.intValue()).replace(',', '.') : ''}"
+                       th:value="${amountInputValue}"
                        required>
+                <small class="form-hint">Nhập tổng số tiền cần thu. Nếu chọn "Cả phòng", khoản này sẽ được chia đều cho từng hợp đồng trong phòng.</small>
             </div>
             <div class="form-group">
                 <label for="dueDate">Ngày Đáo Hạn</label>

--- a/src/main/resources/templates/fees/list.html
+++ b/src/main/resources/templates/fees/list.html
@@ -30,7 +30,9 @@
                     <th>Phòng</th>
                     <th>SĐT</th>
                     <th>Loại Phí</th>
+                    <th>Phạm Vi</th>
                     <th>Số Tiền</th>
+                    <th>Tổng Phí</th>
                     <th>Thao Tác</th>
                 </tr>
             </thead>
@@ -43,7 +45,9 @@
                     <td th:text="${fee.contract != null && fee.contract.room != null ? fee.contract.room.number : ''}"></td>
                     <td th:text="${fee.contract != null && fee.contract.student != null ? fee.contract.student.phone : ''}"></td>
                     <td th:text="${fee.type}"></td>
-                    <td th:text="${T(java.lang.String).format('%,d', fee.amount.intValue()).replace(',', '.')}" ></td>
+                    <td th:text="${fee.scope == null ? 'Cá nhân' : (fee.scope.name() == 'ROOM' ? 'Cả phòng' : 'Cá nhân')}"></td>
+                    <td th:text="${T(java.lang.String).format('%,d', fee.amount.longValue()).replace(',', '.')}" ></td>
+                    <td th:text="${fee.totalAmount != null ? T(java.lang.String).format('%,d', fee.totalAmount.longValue()).replace(',', '.') : ''}"></td>
                     <td class="action-icons">
                         <a th:href="@{/fees/{id}(id=${fee.id})}" class="view"><i class="fas fa-eye"></i></a>
                         <a th:href="@{/fees/{id}/edit(id=${fee.id})}" class="edit"><i class="fas fa-edit"></i></a>

--- a/src/main/resources/templates/reports/overview.html
+++ b/src/main/resources/templates/reports/overview.html
@@ -52,6 +52,57 @@
             </div>
         </div>
 
+        <h3>Thống kê phí</h3>
+        <div class="responsive-table">
+            <table>
+                <thead>
+                <tr>
+                    <th>Phạm vi</th>
+                    <th>Số khoản</th>
+                    <th>Tổng cần thu</th>
+                    <th>Còn chưa thu</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="summary : ${feeScopeSummaries}">
+                    <td th:text="${summary.displayName()}"></td>
+                    <td th:text="${summary.feeCount()}"></td>
+                    <td th:text="${#numbers.formatDecimal(summary.totalAmount(), 0, 0)} + ' ₫'"></td>
+                    <td th:text="${#numbers.formatDecimal(summary.unpaidAmount(), 0, 0)} + ' ₫'"></td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(feeScopeSummaries)}">
+                    <td colspan="4">Chưa có dữ liệu phí theo phạm vi.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="responsive-table">
+            <table>
+                <thead>
+                <tr>
+                    <th>Loại phí</th>
+                    <th>Số khoản</th>
+                    <th>Tổng cần thu</th>
+                    <th>Số khoản chưa thu</th>
+                    <th>Còn chưa thu</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="summary : ${feeTypeSummaries}">
+                    <td th:text="${summary.displayName()}"></td>
+                    <td th:text="${summary.feeCount()}"></td>
+                    <td th:text="${#numbers.formatDecimal(summary.totalAmount(), 0, 0)} + ' ₫'"></td>
+                    <td th:text="${summary.unpaidCount()}"></td>
+                    <td th:text="${#numbers.formatDecimal(summary.unpaidAmount(), 0, 0)} + ' ₫'"></td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(feeTypeSummaries)}">
+                    <td colspan="5">Chưa có dữ liệu phí theo loại.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
         <h3>Hiệu suất theo tòa</h3>
         <div class="responsive-table">
             <table>

--- a/src/main/resources/templates/student/fees.html
+++ b/src/main/resources/templates/student/fees.html
@@ -24,6 +24,7 @@
                 <thead>
                 <tr>
                     <th>Loại phí</th>
+                    <th>Phạm vi</th>
                     <th>Số tiền</th>
                     <th>Hạn thanh toán</th>
                     <th>Trạng thái</th>
@@ -32,7 +33,13 @@
                 <tbody>
                 <tr th:each="fee : ${fees}" class="table-row">
                     <td th:text="${fee.type}"></td>
-                    <td th:text="${#numbers.formatCurrency(fee.amount)}"></td>
+                    <td th:text="${fee.scope == null ? 'Cá nhân' : (fee.scope.name() == 'ROOM' ? 'Cả phòng' : 'Cá nhân')}"></td>
+                    <td>
+                        <span th:text="${#numbers.formatCurrency(fee.amount)}"></span>
+                        <div th:if="${fee.scope != null && fee.scope.name() == 'ROOM'}" class="text-muted">
+                            <small>Chia từ tổng <span th:text="${#numbers.formatCurrency(fee.totalAmount)}"></span></small>
+                        </div>
+                    </td>
                     <td th:text="${#temporals.format(fee.dueDate, 'dd/MM/yyyy')}"></td>
                     <td>
                         <span class="badge"


### PR DESCRIPTION
## Summary
- introduce fee scope metadata, distribution logic, and grouping helpers so room-wide charges are split across contracts
- refresh administrative and student fee screens to capture scope choice, show per-person shares, and display total amounts
- extend the reports overview with fee scope/type tables and supporting DTOs plus styling tweaks for form guidance

## Testing
- mvn -q -DskipTests package *(fails: repository access to Spring Boot parent is forbidden in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbef36c5508326bf7f8df9e57a813b