### PR TITLE
Enhance fee scope selection and report visuals

### DIFF
--- a/src/main/java/com/example/dorm/controller/BuildingController.java
+++ b/src/main/java/com/example/dorm/controller/BuildingController.java
@@ -9,7 +9,11 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+import java.util.Map;
 
 @Controller
 @RequestMapping("/buildings")
@@ -25,6 +29,18 @@ public class BuildingController {
     public String listBuildings(Model model) {
         model.addAttribute("buildingSummaries", buildingService.getBuildingSummaries());
         return "buildings/list";
+    }
+
+    @GetMapping(value = "/options", produces = "application/json")
+    @ResponseBody
+    public List<Map<String, Object>> buildingOptions() {
+        return buildingService.getAllBuildings().stream()
+                .map(building -> Map.<String, Object>of(
+                        "id", building.getId(),
+                        "code", building.getCode(),
+                        "name", building.getName()
+                ))
+                .toList();
     }
 
     @GetMapping("/new")

--- a/src/main/java/com/example/dorm/controller/ContractController.java
+++ b/src/main/java/com/example/dorm/controller/ContractController.java
@@ -151,5 +151,22 @@ public class ContractController {
                 .toList();
     }
 
+    @GetMapping(value = "/by-room/{roomId}", produces = "application/json")
+    @ResponseBody
+    public List<Map<String, Object>> contractsByRoom(@PathVariable("roomId") Long roomId) {
+        return contractService.getContractsByRoom(roomId).stream()
+                .map(contract -> {
+                    String label = contract.getStudent() != null
+                            ? contract.getStudent().getCode() + " - " + contract.getStudent().getName()
+                            : "Hợp đồng #" + contract.getId();
+                    return Map.<String, Object>of(
+                            "id", contract.getId(),
+                            "label", label,
+                            "roomId", contract.getRoom() != null ? contract.getRoom().getId() : null
+                    );
+                })
+                .toList();
+    }
+
     // search handled by listContracts
 }

--- a/src/main/java/com/example/dorm/controller/ReportController.java
+++ b/src/main/java/com/example/dorm/controller/ReportController.java
@@ -118,6 +118,35 @@ public class ReportController {
                 .sorted(Comparator.comparing(summary -> summary.scope().name()))
                 .toList();
 
+        List<Map<String, Object>> feeScopeChartData = feeScopeSummaries.stream()
+                .map(summary -> Map.<String, Object>of(
+                        "label", summary.displayName(),
+                        "count", summary.feeCount(),
+                        "totalAmount", summary.totalAmount(),
+                        "unpaidAmount", summary.unpaidAmount()
+                ))
+                .toList();
+
+        List<Map<String, Object>> feeTypeChartData = feeTypeSummaries.stream()
+                .map(summary -> Map.<String, Object>of(
+                        "label", summary.displayName(),
+                        "count", summary.feeCount(),
+                        "unpaidCount", summary.unpaidCount(),
+                        "totalAmount", summary.totalAmount(),
+                        "unpaidAmount", summary.unpaidAmount()
+                ))
+                .toList();
+
+        List<Map<String, Object>> buildingOccupancyChartData = buildingSummaries.stream()
+                .map(summary -> Map.<String, Object>of(
+                        "label", summary.code() != null ? summary.code() : summary.name(),
+                        "name", summary.name(),
+                        "rate", summary.occupancyRate(),
+                        "capacity", summary.capacity(),
+                        "occupied", summary.occupiedBeds()
+                ))
+                .toList();
+
         model.addAttribute("buildingSummaries", buildingSummaries);
         model.addAttribute("buildingCount", buildingSummaries.size());
         model.addAttribute("studentCount", studentService.countStudents());
@@ -131,6 +160,9 @@ public class ReportController {
         model.addAttribute("outstandingRevenue", outstandingRevenue);
         model.addAttribute("feeTypeSummaries", feeTypeSummaries);
         model.addAttribute("feeScopeSummaries", feeScopeSummaries);
+        model.addAttribute("feeScopeChartData", feeScopeChartData);
+        model.addAttribute("feeTypeChartData", feeTypeChartData);
+        model.addAttribute("buildingOccupancyChartData", buildingOccupancyChartData);
 
         return "reports/overview";
     }

--- a/src/main/java/com/example/dorm/controller/RoomController.java
+++ b/src/main/java/com/example/dorm/controller/RoomController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.LinkedHashMap;
@@ -63,6 +64,18 @@ public class RoomController {
         model.addAttribute("search", search);
         model.addAttribute("selectedBuildingId", buildingId);
         return "rooms/list";
+    }
+
+    @GetMapping(value = "/by-building/{buildingId}", produces = "application/json")
+    @ResponseBody
+    public List<Map<String, Object>> roomsByBuilding(@PathVariable("buildingId") Long buildingId) {
+        return roomService.getRoomsByBuilding(buildingId).stream()
+                .map(room -> Map.<String, Object>of(
+                        "id", room.getId(),
+                        "number", room.getNumber(),
+                        "buildingId", room.getBuilding() != null ? room.getBuilding().getId() : null
+                ))
+                .toList();
     }
 
     @GetMapping("/new")

--- a/src/main/java/com/example/dorm/service/ContractService.java
+++ b/src/main/java/com/example/dorm/service/ContractService.java
@@ -115,6 +115,13 @@ public class ContractService {
         return contractRepository.findByStudent_Id(studentId);
     }
 
+    public List<Contract> getContractsByRoom(Long roomId) {
+        if (roomId == null) {
+            return List.of();
+        }
+        return contractRepository.findByRoom_Id(roomId);
+    }
+
     public Page<Contract> searchContracts(String search, Pageable pageable) {
         if (search == null || search.trim().isEmpty()) {
             return contractRepository.findAll(pageable);

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1432,6 +1432,35 @@ h2 {
     margin-bottom: 1.5rem;
 }
 
+.chart-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin: 1.5rem 0;
+}
+
+.chart-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 1.25rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.chart-card h4 {
+    margin-bottom: 1rem;
+    font-size: 1.05rem;
+}
+
+.chart-card canvas {
+    width: 100% !important;
+    max-height: 320px;
+}
+
+.chart-card .empty-state {
+    margin: 0;
+}
+
 .detail-card {
     background: var(--bg-secondary);
     border: 1px solid var(--border-color);

--- a/src/main/resources/templates/fees/form.html
+++ b/src/main/resources/templates/fees/form.html
@@ -13,12 +13,38 @@
         <div class="form-container">
         <h2 th:text="${fee.id} ? 'Sửa Phí' : 'Thêm Phí'"></h2>
         <form th:action="${fee.id} ? @{/fees/{id}(id=${fee.id})} : @{/fees}" th:object="${fee}" method="post">
-            <div class="form-group">
+            <div class="form-group" id="contractGroup">
                 <label for="contractInput">Hợp Đồng</label>
                 <input type="text" id="contractInput" list="contractOptions" autocomplete="off"
                        th:value="${fee.contract != null && fee.contract.student != null ? fee.contract.id + ' - ' + fee.contract.student.code + ' - ' + fee.contract.student.name : ''}">
                 <datalist id="contractOptions"></datalist>
                 <input type="hidden" id="contractId" th:field="*{contract.id}">
+            </div>
+            <div id="roomScopeFields" class="form-group-grid" hidden
+                 th:attr="data-selected-building=${fee.contract != null && fee.contract.room != null && fee.contract.room.building != null ? fee.contract.room.building.id : ''},
+                          data-selected-room=${fee.contract != null && fee.contract.room != null ? fee.contract.room.id : ''},
+                          data-selected-contract=${fee.contract != null ? fee.contract.id : ''}">
+                <div class="form-group">
+                    <label for="buildingSelect">Tòa nhà</label>
+                    <select id="buildingSelect">
+                        <option value="">-- Chọn tòa --</option>
+                    </select>
+                    <small class="form-hint">Chọn tòa nhà để hiển thị các phòng tương ứng.</small>
+                </div>
+                <div class="form-group">
+                    <label for="roomSelect">Phòng</label>
+                    <select id="roomSelect" disabled>
+                        <option value="">-- Chọn phòng --</option>
+                    </select>
+                    <small class="form-hint">Chọn phòng áp dụng để hệ thống phân bổ cho các hợp đồng trong phòng.</small>
+                </div>
+                <div class="form-group">
+                    <label for="roomContractSelect">Hợp đồng đại diện</label>
+                    <select id="roomContractSelect" disabled>
+                        <option value="">-- Chọn sinh viên --</option>
+                    </select>
+                    <small class="form-hint">Chọn một hợp đồng trong phòng làm cơ sở phân bổ phí.</small>
+                </div>
             </div>
             <div class="form-group">
                 <label for="type">Loại Phí</label>
@@ -68,6 +94,16 @@
         const cInput = document.getElementById('contractInput');
         const cList = document.getElementById('contractOptions');
         const cHidden = document.getElementById('contractId');
+        const scopeSelect = document.getElementById('scope');
+        const contractGroup = document.getElementById('contractGroup');
+        const roomScopeFields = document.getElementById('roomScopeFields');
+        const buildingSelect = document.getElementById('buildingSelect');
+        const roomSelect = document.getElementById('roomSelect');
+        const roomContractSelect = document.getElementById('roomContractSelect');
+
+        const selectedBuildingId = roomScopeFields.dataset.selectedBuilding;
+        const selectedRoomId = roomScopeFields.dataset.selectedRoom;
+        const selectedContractId = roomScopeFields.dataset.selectedContract;
 
         function fetchContracts(q) {
             if (!q) { cList.innerHTML = ''; return; }
@@ -84,6 +120,96 @@
                 });
         }
 
+        function toggleScopeFields() {
+            const isRoomScope = scopeSelect.value === 'ROOM';
+            contractGroup.hidden = isRoomScope;
+            roomScopeFields.hidden = !isRoomScope;
+            buildingSelect.required = isRoomScope;
+            roomSelect.required = isRoomScope;
+            roomContractSelect.required = isRoomScope;
+            if (!isRoomScope) {
+                buildingSelect.value = '';
+                roomSelect.innerHTML = '<option value="">-- Chọn phòng --</option>';
+                roomSelect.disabled = true;
+                roomContractSelect.innerHTML = '<option value="">-- Chọn sinh viên --</option>';
+                roomContractSelect.disabled = true;
+            } else {
+                cHidden.value = '';
+            }
+        }
+
+        function loadBuildings() {
+            fetch('/buildings/options')
+                .then(r => r.json())
+                .then(data => {
+                    buildingSelect.innerHTML = '<option value="">-- Chọn tòa --</option>';
+                    data.forEach(building => {
+                        const option = document.createElement('option');
+                        option.value = building.id;
+                        option.textContent = building.code ? `${building.code} - ${building.name}` : building.name;
+                        buildingSelect.appendChild(option);
+                    });
+                    if (selectedBuildingId) {
+                        buildingSelect.value = selectedBuildingId;
+                        loadRooms(selectedBuildingId, selectedRoomId, selectedContractId);
+                    }
+                });
+        }
+
+        function loadRooms(buildingId, roomIdToSelect, contractIdToSelect) {
+            if (!buildingId) {
+                roomSelect.innerHTML = '<option value="">-- Chọn phòng --</option>';
+                roomSelect.disabled = true;
+                roomContractSelect.innerHTML = '<option value="">-- Chọn sinh viên --</option>';
+                roomContractSelect.disabled = true;
+                return;
+            }
+            fetch(`/rooms/by-building/${buildingId}`)
+                .then(r => r.json())
+                .then(data => {
+                    roomSelect.innerHTML = '<option value="">-- Chọn phòng --</option>';
+                    data.forEach(room => {
+                        const option = document.createElement('option');
+                        option.value = room.id;
+                        option.textContent = `Phòng ${room.number}`;
+                        roomSelect.appendChild(option);
+                    });
+                    roomSelect.disabled = false;
+                    if (roomIdToSelect) {
+                        roomSelect.value = roomIdToSelect;
+                        loadRoomContracts(roomIdToSelect, contractIdToSelect);
+                    }
+                });
+        }
+
+        function loadRoomContracts(roomId, contractIdToSelect) {
+            if (!roomId) {
+                roomContractSelect.innerHTML = '<option value="">-- Chọn sinh viên --</option>';
+                roomContractSelect.disabled = true;
+                cHidden.value = '';
+                return;
+            }
+            fetch(`/contracts/by-room/${roomId}`)
+                .then(r => r.json())
+                .then(data => {
+                    roomContractSelect.innerHTML = '<option value="">-- Chọn sinh viên --</option>';
+                    data.forEach(contract => {
+                        const option = document.createElement('option');
+                        option.value = contract.id;
+                        option.textContent = contract.label;
+                        roomContractSelect.appendChild(option);
+                    });
+                    roomContractSelect.disabled = data.length === 0;
+                    if (data.length === 0) {
+                        roomContractSelect.insertAdjacentHTML('beforeend', '<option value="" disabled>Phòng chưa có hợp đồng</option>');
+                    }
+                    if (contractIdToSelect) {
+                        roomContractSelect.value = contractIdToSelect;
+                        cHidden.value = contractIdToSelect;
+                    }
+                });
+        }
+
         cInput.addEventListener('input', () => {
             fetchContracts(cInput.value);
             const opt = Array.from(cList.options).find(o => o.value === cInput.value);
@@ -94,6 +220,34 @@
             cHidden.value = opt ? opt.dataset.id : '';
         });
         if (cInput.value) { fetchContracts(cInput.value); }
+
+        scopeSelect.addEventListener('change', () => {
+            toggleScopeFields();
+            if (scopeSelect.value === 'ROOM' && buildingSelect.options.length <= 1) {
+                loadBuildings();
+            }
+        });
+
+        buildingSelect.addEventListener('change', () => {
+            cHidden.value = '';
+            roomContractSelect.value = '';
+            loadRooms(buildingSelect.value, null, null);
+        });
+
+        roomSelect.addEventListener('change', () => {
+            cHidden.value = '';
+            roomContractSelect.value = '';
+            loadRoomContracts(roomSelect.value, null);
+        });
+
+        roomContractSelect.addEventListener('change', () => {
+            cHidden.value = roomContractSelect.value;
+        });
+
+        toggleScopeFields();
+        if (scopeSelect.value === 'ROOM') {
+            loadBuildings();
+        }
         /*]]>*/
     </script>
 </body>

--- a/src/main/resources/templates/reports/overview.html
+++ b/src/main/resources/templates/reports/overview.html
@@ -77,6 +77,24 @@
             </table>
         </div>
 
+        <div class="chart-grid">
+            <div class="chart-card">
+                <h4>Phân bổ phí theo phạm vi</h4>
+                <canvas id="feeScopeChart"></canvas>
+                <p class="empty-state" id="feeScopeChartEmpty">Chưa có dữ liệu để hiển thị.</p>
+            </div>
+            <div class="chart-card">
+                <h4>Phân bổ phí theo loại</h4>
+                <canvas id="feeTypeChart"></canvas>
+                <p class="empty-state" id="feeTypeChartEmpty">Chưa có dữ liệu để hiển thị.</p>
+            </div>
+            <div class="chart-card">
+                <h4>Tỷ lệ lấp đầy theo tòa</h4>
+                <canvas id="buildingOccupancyChart"></canvas>
+                <p class="empty-state" id="buildingOccupancyChartEmpty">Chưa có dữ liệu để hiển thị.</p>
+            </div>
+        </div>
+
         <div class="responsive-table">
             <table>
                 <thead>
@@ -164,5 +182,174 @@
         </div>
     </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+<script th:inline="javascript">
+    /*<![CDATA[*/
+    const feeScopeChartData = /*[[${feeScopeChartData}]]*/ [];
+    const feeTypeChartData = /*[[${feeTypeChartData}]]*/ [];
+    const buildingOccupancyChartData = /*[[${buildingOccupancyChartData}]]*/ [];
+
+    const formatter = new Intl.NumberFormat('vi-VN');
+
+    function toNumber(value) {
+        if (value === null || value === undefined) {
+            return 0;
+        }
+        if (typeof value === 'number') {
+            return value;
+        }
+        if (typeof value === 'string') {
+            const normalized = value.replace(/[,\s]/g, '');
+            const parsed = Number(normalized);
+            return isNaN(parsed) ? 0 : parsed;
+        }
+        if (typeof value === 'object' && 'value' in value) {
+            return toNumber(value.value);
+        }
+        const parsed = Number(value);
+        return isNaN(parsed) ? 0 : parsed;
+    }
+
+    function toggleEmptyState(canvasId, emptyId, hasData) {
+        const canvas = document.getElementById(canvasId);
+        const empty = document.getElementById(emptyId);
+        if (canvas) {
+            canvas.style.display = hasData ? 'block' : 'none';
+        }
+        if (empty) {
+            empty.style.display = hasData ? 'none' : 'block';
+        }
+    }
+
+    if (typeof Chart !== 'undefined') {
+        toggleEmptyState('feeScopeChart', 'feeScopeChartEmpty', feeScopeChartData.length > 0);
+        if (feeScopeChartData.length > 0) {
+            const scopeCtx = document.getElementById('feeScopeChart');
+            const scopeLabels = feeScopeChartData.map(item => item.label);
+            const scopeTotals = feeScopeChartData.map(item => toNumber(item.totalAmount));
+            new Chart(scopeCtx, {
+                type: 'doughnut',
+                data: {
+                    labels: scopeLabels,
+                    datasets: [{
+                        label: 'Tổng cần thu',
+                        data: scopeTotals,
+                        backgroundColor: ['#3b82f6', '#10b981', '#f59e0b', '#6366f1'],
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    plugins: {
+                        legend: { position: 'bottom' },
+                        tooltip: {
+                            callbacks: {
+                                label: context => {
+                                    const unpaid = toNumber(feeScopeChartData[context.dataIndex].unpaidAmount);
+                                    const total = context.parsed;
+                                    const unpaidText = unpaid > 0 ? ` (Chưa thu: ${formatter.format(unpaid)} ₫)` : '';
+                                    return `${context.label}: ${formatter.format(total)} ₫${unpaidText}`;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        toggleEmptyState('feeTypeChart', 'feeTypeChartEmpty', feeTypeChartData.length > 0);
+        if (feeTypeChartData.length > 0) {
+            const typeCtx = document.getElementById('feeTypeChart');
+            const typeLabels = feeTypeChartData.map(item => item.label);
+            const typeTotals = feeTypeChartData.map(item => toNumber(item.totalAmount));
+            const typeUnpaid = feeTypeChartData.map(item => toNumber(item.unpaidAmount));
+            new Chart(typeCtx, {
+                type: 'bar',
+                data: {
+                    labels: typeLabels,
+                    datasets: [
+                        {
+                            label: 'Tổng cần thu',
+                            data: typeTotals,
+                            backgroundColor: '#3b82f6'
+                        },
+                        {
+                            label: 'Chưa thu',
+                            data: typeUnpaid,
+                            backgroundColor: '#ef4444'
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        y: {
+                            ticks: {
+                                callback: value => `${formatter.format(value)} ₫`
+                            },
+                            beginAtZero: true
+                        }
+                    },
+                    plugins: {
+                        tooltip: {
+                            callbacks: {
+                                label: context => `${context.dataset.label}: ${formatter.format(context.parsed.y)} ₫`
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        toggleEmptyState('buildingOccupancyChart', 'buildingOccupancyChartEmpty', buildingOccupancyChartData.length > 0);
+        if (buildingOccupancyChartData.length > 0) {
+            const occupancyCtx = document.getElementById('buildingOccupancyChart');
+            const occupancyLabels = buildingOccupancyChartData.map(item => item.label || item.name);
+            const occupancyRates = buildingOccupancyChartData.map(item => toNumber(item.rate));
+            const occupancyMeta = buildingOccupancyChartData.map(item => ({
+                name: item.name,
+                occupied: toNumber(item.occupied),
+                capacity: toNumber(item.capacity)
+            }));
+            new Chart(occupancyCtx, {
+                type: 'bar',
+                data: {
+                    labels: occupancyLabels,
+                    datasets: [{
+                        label: 'Tỷ lệ lấp đầy (%)',
+                        data: occupancyRates,
+                        backgroundColor: '#10b981'
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    scales: {
+                        x: {
+                            max: 100,
+                            ticks: {
+                                callback: value => `${value}%`
+                            },
+                            beginAtZero: true
+                        }
+                    },
+                    plugins: {
+                        tooltip: {
+                            callbacks: {
+                                label: context => {
+                                    const meta = occupancyMeta[context.dataIndex];
+                                    return `${meta.name}: ${context.parsed.x}% (${meta.occupied}/${meta.capacity} giường)`;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    } else {
+        toggleEmptyState('feeScopeChart', 'feeScopeChartEmpty', false);
+        toggleEmptyState('feeTypeChart', 'feeTypeChartEmpty', false);
+        toggleEmptyState('buildingOccupancyChart', 'buildingOccupancyChartEmpty', false);
+    }
+    /*]]>*/
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add building and room selectors to the fee form so room-wide fees can target a specific tower and room, including dynamic contract lookup
- expose lightweight JSON endpoints for buildings, rooms, and room contracts to power the enhanced fee workflow
- add responsive Chart.js visualizations and supporting styles to the reports overview to make fee and occupancy data easier to digest

## Testing
- mvn -q -DskipTests package *(fails: unable to download Spring Boot parent POM – HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf41c978083269ad63e7db4436689