### PR TITLE
Align database schema with application entities

### DIFF
--- a/src/main/resources/database.sql
+++ b/src/main/resources/database.sql
@@ -9,76 +9,6 @@ CREATE DATABASE IF NOT EXISTS dormitory_db
 USE dormitory_db;
 
 -- ============================================
--- TABLE: STUDENT
--- ============================================
-CREATE TABLE student (
-                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                         code VARCHAR(50) UNIQUE,
-                         name VARCHAR(255) NOT NULL,
-                         dob DATE,
-                         gender ENUM('Nam', 'Nữ'),
-                         phone VARCHAR(20),
-                         address VARCHAR(255),
-                         email VARCHAR(255),
-                         department VARCHAR(255),
-                         year INT,
-                         user_id BIGINT UNIQUE,
-                         CONSTRAINT chk_email UNIQUE (email)
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
--- ============================================
--- TABLE: BUILDING
--- ============================================
-CREATE TABLE building (
-                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                          code VARCHAR(50) UNIQUE NOT NULL,
-                          name VARCHAR(255) NOT NULL,
-                          address VARCHAR(255),
-                          description TEXT,
-                          total_floors INT
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
--- ============================================
--- TABLE: ROOM
--- ============================================
-CREATE TABLE room (
-                      id        BIGINT AUTO_INCREMENT PRIMARY KEY,
-                      number    VARCHAR(50) UNIQUE NOT NULL,
-                      type      VARCHAR(50),
-                      capacity  INT NOT NULL,
-                      price     DECIMAL(10,2) DEFAULT 0.00,
-                      building_id BIGINT,
-                      CONSTRAINT fk_room_building FOREIGN KEY (building_id) REFERENCES building(id) ON DELETE SET NULL
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
--- ============================================
--- TABLE: CONTRACT
--- ============================================
-CREATE TABLE contract (
-                          id         BIGINT AUTO_INCREMENT PRIMARY KEY,
-                          student_id BIGINT,
-                          room_id    BIGINT,
-                          start_date DATE,
-                          end_date   DATE,
-                          status     ENUM('ACTIVE', 'EXPIRED'),
-                          FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE,
-                          FOREIGN KEY (room_id)    REFERENCES room(id)    ON DELETE CASCADE
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
--- ============================================
--- TABLE: FEE
--- ============================================
-CREATE TABLE fee (
-                     id             BIGINT AUTO_INCREMENT PRIMARY KEY,
-                     contract_id    BIGINT,
-                     type           VARCHAR(50),
-                     amount         DECIMAL(10,2),
-                     due_date       DATE,
-                     payment_status ENUM('PAID', 'UNPAID'),
-                     FOREIGN KEY (contract_id) REFERENCES contract(id) ON DELETE CASCADE
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
--- ============================================
 -- TABLE: ROLE
 -- ============================================
 CREATE TABLE role (
@@ -88,7 +18,7 @@ CREATE TABLE role (
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- ============================================
--- TABLE: USERS (UPDATED WITH MISSING COLUMNS)
+-- TABLE: USERS
 -- ============================================
 CREATE TABLE users (
                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -112,9 +42,115 @@ CREATE TABLE user_roles (
                             FOREIGN KEY (role_id) REFERENCES role(id) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-ALTER TABLE student
-    ADD CONSTRAINT fk_student_user
-        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;
+-- ============================================
+-- TABLE: BUILDING
+-- ============================================
+CREATE TABLE building (
+                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                          code VARCHAR(50) UNIQUE NOT NULL,
+                          name VARCHAR(255) NOT NULL,
+                          address VARCHAR(255),
+                          description TEXT,
+                          total_floors INT
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================
+-- TABLE: ROOM
+-- ============================================
+CREATE TABLE room (
+                      id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+                      number      VARCHAR(50) UNIQUE NOT NULL,
+                      type        VARCHAR(50),
+                      capacity    INT NOT NULL,
+                      price       INT DEFAULT 0,
+                      building_id BIGINT,
+                      CONSTRAINT fk_room_building FOREIGN KEY (building_id) REFERENCES building(id) ON DELETE SET NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================
+-- TABLE: STUDENT
+-- ============================================
+CREATE TABLE student (
+                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         code VARCHAR(50) UNIQUE,
+                         name VARCHAR(255) NOT NULL,
+                         dob DATE,
+                         gender ENUM('Nam', 'Nữ', 'Khác'),
+                         phone VARCHAR(20),
+                         address VARCHAR(255),
+                         email VARCHAR(255),
+                         department VARCHAR(255),
+                         study_year INT,
+                         room_id BIGINT,
+                         user_id BIGINT UNIQUE,
+                         CONSTRAINT chk_email UNIQUE (email),
+                         CONSTRAINT fk_student_room FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE SET NULL,
+                         CONSTRAINT fk_student_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================
+-- TABLE: CONTRACT
+-- ============================================
+CREATE TABLE contract (
+                          id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+                          student_id BIGINT,
+                          room_id    BIGINT,
+                          start_date DATE,
+                          end_date   DATE,
+                          status     VARCHAR(50),
+                          FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE,
+                          FOREIGN KEY (room_id)    REFERENCES room(id)    ON DELETE CASCADE
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================
+-- TABLE: FEE
+-- ============================================
+CREATE TABLE fee (
+                     id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+                     contract_id    BIGINT,
+                     type           VARCHAR(50),
+                     scope          VARCHAR(20) DEFAULT 'INDIVIDUAL',
+                     amount         DECIMAL(10,2),
+                     total_amount   DECIMAL(10,2),
+                     group_code     VARCHAR(100),
+                     due_date       DATE,
+                     payment_status VARCHAR(20) DEFAULT 'UNPAID',
+                     FOREIGN KEY (contract_id) REFERENCES contract(id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================
+-- TABLE: DORM_REGISTRATION_PERIOD
+-- ============================================
+CREATE TABLE dorm_registration_period (
+                                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                          name VARCHAR(150) NOT NULL,
+                                          start_time DATETIME,
+                                          end_time DATETIME,
+                                          capacity INT,
+                                          notes TEXT,
+                                          status VARCHAR(50) DEFAULT 'SCHEDULED',
+                                          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                                          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================
+-- TABLE: DORM_REGISTRATION_REQUEST
+-- ============================================
+CREATE TABLE dorm_registration_request (
+                                           id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                           student_id BIGINT,
+                                           period_id BIGINT,
+                                           desired_room_type VARCHAR(100),
+                                           preferred_room_number VARCHAR(50),
+                                           expected_move_in_date DATE,
+                                           additional_notes TEXT,
+                                           status VARCHAR(50) DEFAULT 'PENDING',
+                                           admin_notes TEXT,
+                                           created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                                           updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                                           FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE,
+                                           FOREIGN KEY (period_id) REFERENCES dorm_registration_period(id) ON DELETE SET NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- ============================================
 -- TABLE: MAINTENANCE_REQUEST
@@ -130,51 +166,39 @@ CREATE TABLE maintenance_request (
                                      resolution_notes TEXT,
                                      handled_by_id BIGINT,
                                      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                                     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                                     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                                      FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE,
                                      FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE SET NULL,
                                      FOREIGN KEY (handled_by_id) REFERENCES users(id) ON DELETE SET NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- ============================================
--- TABLE: DORM_REGISTRATION_REQUEST
--- ============================================
-CREATE TABLE dorm_registration_request (
-                                           id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                                           student_id BIGINT,
-                                           desired_room_type VARCHAR(100),
-                                           preferred_room_number VARCHAR(50),
-                                           expected_move_in_date DATE,
-                                           additional_notes TEXT,
-                                           status VARCHAR(50),
-                                           admin_notes TEXT,
-                                           created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                                           updated_at DATETIME NULL,
-                                           FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
--- ============================================
 -- TABLE: VIOLATION
 -- ============================================
 CREATE TABLE violation (
-                           id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                           student_id BIGINT,
-                           room_id BIGINT,
-                           description TEXT,
-                           severity VARCHAR(50),
-                           date DATE,
-                           FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE,
-                           FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE SET NULL
+                            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                            student_id BIGINT,
+                            room_id BIGINT,
+                            description TEXT,
+                            severity VARCHAR(50),
+                            date DATE DEFAULT CURRENT_DATE,
+                            type VARCHAR(100),
+                            created_by_id BIGINT,
+                            FOREIGN KEY (student_id) REFERENCES student(id) ON DELETE CASCADE,
+                            FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE SET NULL,
+                            FOREIGN KEY (created_by_id) REFERENCES users(id) ON DELETE SET NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- ============================================
--- DATA: ROLE (CHỈ ADMIN)
+-- DATA: ROLE
 -- ============================================
 INSERT INTO role (name, description) VALUES
-    ('ROLE_ADMIN','Quản lý KTX');
+    ('ROLE_ADMIN','Quản lý KTX'),
+    ('ROLE_STAFF','Nhân viên hỗ trợ'),
+    ('ROLE_STUDENT','Sinh viên');
 
 -- ============================================
--- DATA: USERS (CHỈ ADMIN)
+-- DATA: USERS
 -- ============================================
 -- Tài khoản admin với password đã mã hóa BCrypt
 -- Username: admin
@@ -183,7 +207,7 @@ INSERT INTO users (username, password, email, full_name, phone, avatar_filename,
     ('admin','$2b$10$M3oiNW5nwPFCycTQFeU1MO8QFSHE.y5QlcvQcqbji6ZPFVU9H5OP6','admin@example.com','Administrator',NULL,NULL,TRUE);
 
 -- ============================================
--- DATA: USER_ROLES (CHỈ ADMIN)
+-- DATA: USER_ROLES
 -- ============================================
 INSERT INTO user_roles (user_id, role_id) VALUES
     (1, 1); -- admin -> ROLE_ADMIN


### PR DESCRIPTION
## Summary
- restructure the SQL schema so table definitions and foreign keys match the current JPA entities
- add missing tables and columns for registration periods, fees, violations, and student links, plus adjust data types and defaults
- seed the full role list and retain the initial admin account mapping

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4b7c420888326b5a1c3fc0f8a7042