### PR TITLE
Ensure transactional student account creation

### DIFF
--- a/src/main/java/com/example/dorm/service/StudentService.java
+++ b/src/main/java/com/example/dorm/service/StudentService.java
@@ -7,6 +7,7 @@ import com.example.dorm.model.User;
 import com.example.dorm.repository.RoomRepository;
 import com.example.dorm.repository.StudentRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,14 +53,17 @@ public class StudentService {
                 .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy sinh viên với ID: " + id));
     }
 
+    @Transactional
     public Student saveStudent(Student student) {
         normalizeStudent(student);
 
-        User existingAccount = null;
+        User existingAccount = student.getUser();
         if (student.getId() != null) {
             Student persisted = getRequiredStudent(student.getId());
-            existingAccount = persisted.getUser();
-            student.setUser(existingAccount);
+            if (existingAccount == null) {
+                existingAccount = persisted.getUser();
+                student.setUser(existingAccount);
+            }
         }
 
         validateUniqueCode(student);
@@ -103,6 +107,7 @@ public class StudentService {
         return studentRepository.count();
     }
 
+    @Transactional
     public Student updateContactInfo(Long studentId, String phone, String email, String address) {
         Student student = getRequiredStudent(studentId);
 

--- a/src/test/java/com/example/dorm/service/StudentServiceIntegrationTest.java
+++ b/src/test/java/com/example/dorm/service/StudentServiceIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.example.dorm.service;
+
+import com.example.dorm.model.Role;
+import com.example.dorm.model.RoleName;
+import com.example.dorm.model.Student;
+import com.example.dorm.model.User;
+import com.example.dorm.repository.RoleRepository;
+import com.example.dorm.repository.StudentRepository;
+import com.example.dorm.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class StudentServiceIntegrationTest {
+
+    @Autowired
+    private StudentService studentService;
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        studentRepository.deleteAll();
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
+
+        Role studentRole = new Role();
+        studentRole.setName(RoleName.ROLE_STUDENT);
+        studentRole.setDescription("Student role");
+        roleRepository.save(studentRole);
+    }
+
+    @Test
+    void creatingStudentCreatesLoginAccountWithDefaultPassword() {
+        Student student = buildStudent("SV100", "student100@example.com");
+
+        Student saved = studentService.saveStudent(student);
+
+        assertThat(saved.getUser()).isNotNull();
+        User account = userRepository.findById(saved.getUser().getId()).orElseThrow();
+        assertThat(account.getUsername()).isEqualTo("student100@example.com");
+        assertThat(account.getEmail()).isEqualTo("student100@example.com");
+        assertThat(account.getRoles()).extracting(role -> role.getName()).containsExactly(RoleName.ROLE_STUDENT);
+        assertThat(passwordEncoder.matches("123", account.getPassword())).isTrue();
+    }
+
+    @Test
+    void saveStudentWithExistingAccountKeepsAccountAndUpdatesProfile() {
+        Student existing = buildStudent("SV200", "legacy@example.com");
+        existing = studentRepository.save(existing);
+
+        User customAccount = userService.createUser("custom_username", "student200@example.com", "StrongPass!1", RoleName.ROLE_STUDENT);
+
+        existing.setEmail("student200@example.com");
+        existing.setUser(customAccount);
+        existing.setPhone("0987654321");
+        existing.setName("Updated Name");
+
+        Student updated = studentService.saveStudent(existing);
+
+        assertThat(userRepository.count()).isEqualTo(1);
+        User linkedAccount = userRepository.findById(updated.getUser().getId()).orElseThrow();
+        assertThat(linkedAccount.getId()).isEqualTo(customAccount.getId());
+        assertThat(linkedAccount.getUsername()).isEqualTo("student200@example.com");
+        assertThat(linkedAccount.getEmail()).isEqualTo("student200@example.com");
+        assertThat(linkedAccount.getFullName()).isEqualTo("Updated Name");
+        assertThat(linkedAccount.getPhone()).isEqualTo("0987654321");
+        assertThat(passwordEncoder.matches("StrongPass!1", linkedAccount.getPassword())).isTrue();
+    }
+
+    private Student buildStudent(String code, String email) {
+        Student student = new Student();
+        student.setCode(code);
+        student.setName("Test Student");
+        student.setDob(LocalDate.of(2003, 1, 1));
+        student.setGender("Nam");
+        student.setPhone("0123456789");
+        student.setAddress("123 Test Street");
+        student.setEmail(email);
+        student.setDepartment("IT");
+        student.setStudyYear(2);
+        student.setRoom(null);
+        return student;
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=never
+app.dataset.default-password=123


### PR DESCRIPTION
## Summary
- make student save/contact updates transactional so linked accounts are created/updated atomically
- preserve provided student login accounts while still normalizing them to use email
- add integration tests and an H2-backed test profile covering student account provisioning

## Testing
- `mvn test` *(fails: unable to download spring-boot-starter-parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c27c76108326a26e6c449e86f394