### PR TITLE
Add building detail view and improve header dropdown behavior

### DIFF
--- a/src/main/java/com/example/dorm/controller/BuildingController.java
+++ b/src/main/java/com/example/dorm/controller/BuildingController.java
@@ -31,6 +31,18 @@ public class BuildingController {
         return "buildings/list";
     }
 
+    @GetMapping("/{id}")
+    public String viewBuilding(@PathVariable Long id, Model model, RedirectAttributes redirectAttributes) {
+        try {
+            model.addAttribute("detail", buildingService.getBuildingDetail(id));
+            return "buildings/detail";
+        } catch (IllegalArgumentException ex) {
+            redirectAttributes.addFlashAttribute("message", ex.getMessage());
+            redirectAttributes.addFlashAttribute("alertClass", "alert-danger");
+            return "redirect:/buildings";
+        }
+    }
+
     @GetMapping(value = "/options", produces = "application/json")
     @ResponseBody
     public List<Map<String, Object>> buildingOptions() {

--- a/src/main/java/com/example/dorm/dto/BuildingDetail.java
+++ b/src/main/java/com/example/dorm/dto/BuildingDetail.java
@@ -1,0 +1,45 @@
+package com.example.dorm.dto;
+
+import com.example.dorm.model.Building;
+
+import java.util.List;
+
+public record BuildingDetail(Long id,
+                             String code,
+                             String name,
+                             String address,
+                             String description,
+                             Integer totalFloors,
+                             int roomCount,
+                             long capacity,
+                             long occupiedBeds,
+                             List<BuildingDetailRoom> rooms) {
+
+    public BuildingDetail(Building building,
+                          int roomCount,
+                          long capacity,
+                          long occupiedBeds,
+                          List<BuildingDetailRoom> rooms) {
+        this(building.getId(),
+                building.getCode(),
+                building.getName(),
+                building.getAddress(),
+                building.getDescription(),
+                building.getTotalFloors(),
+                roomCount,
+                capacity,
+                occupiedBeds,
+                rooms);
+    }
+
+    public double occupancyRate() {
+        if (capacity <= 0) {
+            return 0.0;
+        }
+        return (double) occupiedBeds / capacity * 100.0;
+    }
+
+    public boolean hasDescription() {
+        return description != null && !description.isBlank();
+    }
+}

--- a/src/main/java/com/example/dorm/dto/BuildingDetailRoom.java
+++ b/src/main/java/com/example/dorm/dto/BuildingDetailRoom.java
@@ -1,0 +1,16 @@
+package com.example.dorm.dto;
+
+public record BuildingDetailRoom(Long id,
+                                 String number,
+                                 String type,
+                                 int capacity,
+                                 int price,
+                                 long occupiedBeds) {
+
+    public double occupancyRate() {
+        if (capacity <= 0) {
+            return 0.0;
+        }
+        return (double) occupiedBeds / capacity * 100.0;
+    }
+}

--- a/src/main/java/com/example/dorm/repository/RoomRepository.java
+++ b/src/main/java/com/example/dorm/repository/RoomRepository.java
@@ -44,6 +44,15 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
     List<Room> findByBuilding_IdOrderByNumberAsc(Long buildingId);
 
+    @Query("""
+            select r.id as roomId, count(s.id) as occupantCount
+            from Room r
+            left join r.students s
+            where r.building.id = :buildingId
+            group by r.id
+            """)
+    List<Object[]> countOccupancyByBuilding(@Param("buildingId") Long buildingId);
+
     // PHƯƠNG THỨC ĐÃ ĐƯỢC SỬA LỖI
     @Query(value = """
             select r

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -465,6 +465,7 @@ h2 {
     text-decoration: none;
     color: var(--text-secondary);
 }
+.action-icons a.view { color: var(--info-color); }
 .action-icons a.edit { color: var(--warning-color); }
 .action-icons a.delete { color: var(--danger-color); }
 .action-icons a:last-child { margin-right: 0; }
@@ -552,6 +553,121 @@ h2 {
     background: rgba(34,197,94,0.08);
     color: #15803d;
     border-color: rgba(34,197,94,0.3);
+}
+
+.btn-back {
+    background: var(--text-secondary);
+    color: #ffffff;
+}
+
+.btn-back:hover {
+    background: var(--text-primary);
+    color: #ffffff;
+}
+
+.building-detail {
+    max-width: 1100px;
+    margin: 0 auto;
+    background: var(--bg-secondary);
+    padding: 2rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+}
+
+.detail-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.detail-header h2 {
+    margin: 0;
+}
+
+.detail-subtitle {
+    color: var(--text-secondary);
+    margin-top: 0.25rem;
+}
+
+.detail-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.detail-actions .button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.detail-info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.detail-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 1.25rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.detail-card h3 {
+    margin-bottom: 1rem;
+    font-size: 1.1rem;
+}
+
+.detail-list {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.detail-list div {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.detail-list dt {
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.detail-list dd {
+    margin: 0;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-align: right;
+}
+
+.detail-description {
+    margin-bottom: 1.5rem;
+    padding: 1.25rem;
+    background: #f8fafc;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border-color);
+}
+
+.detail-description h3 {
+    margin-bottom: 0.75rem;
+}
+
+.link-inline {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.link-inline:hover {
+    text-decoration: underline;
 }
 
 .form-group {

--- a/src/main/resources/templates/buildings/detail.html
+++ b/src/main/resources/templates/buildings/detail.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="vi" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Chi tiết tòa nhà</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+<div th:replace="fragments/sidebar :: sidebar"></div>
+<div class="content-with-sidebar">
+    <div class="building-detail">
+        <div class="detail-header">
+            <div>
+                <h2 th:text="${detail.name()}">Chi tiết tòa nhà</h2>
+                <p class="detail-subtitle" th:text="${detail.code()}">Mã tòa</p>
+            </div>
+            <div class="detail-actions">
+                <a th:href="@{/buildings/{id}/edit(id=${detail.id()})}" class="button btn-edit"><i class="fas fa-edit"></i> Chỉnh sửa</a>
+                <a th:href="@{/buildings}" class="button btn-back"><i class="fas fa-arrow-left"></i> Quay lại</a>
+            </div>
+        </div>
+
+        <div class="detail-info-grid">
+            <div class="detail-card">
+                <h3>Thông tin chung</h3>
+                <dl class="detail-list">
+                    <div>
+                        <dt>Mã tòa</dt>
+                        <dd th:text="${detail.code()}"></dd>
+                    </div>
+                    <div>
+                        <dt>Tên tòa</dt>
+                        <dd th:text="${detail.name()}"></dd>
+                    </div>
+                    <div>
+                        <dt>Địa chỉ</dt>
+                        <dd th:text="${detail.address() != null ? detail.address() : 'Chưa cập nhật'}"></dd>
+                    </div>
+                    <div>
+                        <dt>Số tầng</dt>
+                        <dd th:text="${detail.totalFloors() != null ? detail.totalFloors() : '-'}"></dd>
+                    </div>
+                </dl>
+            </div>
+            <div class="detail-card">
+                <h3>Thống kê</h3>
+                <dl class="detail-list">
+                    <div>
+                        <dt>Số phòng</dt>
+                        <dd th:text="${detail.roomCount()}"></dd>
+                    </div>
+                    <div>
+                        <dt>Tổng sức chứa</dt>
+                        <dd th:text="${detail.capacity()}"></dd>
+                    </div>
+                    <div>
+                        <dt>Đang ở</dt>
+                        <dd th:text="${detail.occupiedBeds()}"></dd>
+                    </div>
+                    <div>
+                        <dt>Tỉ lệ lấp đầy</dt>
+                        <dd>
+                            <span th:text="${#numbers.formatDecimal(detail.occupancyRate(), 0, 2) + '%'}"
+                                  th:class="${detail.occupancyRate() >= 90 ? 'badge badge-danger' : (detail.occupancyRate() >= 70 ? 'badge badge-warning' : 'badge badge-success')}"></span>
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+        </div>
+
+        <div class="detail-description" th:if="${detail.hasDescription()}">
+            <h3>Mô tả</h3>
+            <p th:text="${detail.description()}"></p>
+        </div>
+
+        <h3>Danh sách phòng</h3>
+        <div class="responsive-table">
+            <table>
+                <thead>
+                <tr>
+                    <th>Số phòng</th>
+                    <th>Loại phòng</th>
+                    <th>Sức chứa</th>
+                    <th>Đang ở</th>
+                    <th>Tỉ lệ lấp đầy</th>
+                    <th>Giá/Tháng</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="room : ${detail.rooms()}">
+                    <td>
+                        <a th:href="@{/rooms/{id}(id=${room.id()})}" th:text="${room.number()}" class="link-inline"></a>
+                    </td>
+                    <td th:text="${room.type() != null ? room.type() : '-'}"></td>
+                    <td th:text="${room.capacity()}"></td>
+                    <td th:text="|${room.occupiedBeds()}/${room.capacity()}|"></td>
+                    <td>
+                        <span th:text="${#numbers.formatDecimal(room.occupancyRate(), 0, 2) + '%'}"
+                              th:class="${room.occupancyRate() >= 90 ? 'badge badge-danger' : (room.occupancyRate() >= 70 ? 'badge badge-warning' : 'badge badge-success')}"></span>
+                    </td>
+                    <td th:text="${T(java.lang.String).format('%,d', room.price()).replace(',', '.')} + ' VNĐ'"></td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(detail.rooms())}">
+                    <td colspan="6">Chưa có phòng nào trong tòa nhà này.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<div th:replace="~{fragments/header :: popup}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/buildings/list.html
+++ b/src/main/resources/templates/buildings/list.html
@@ -46,6 +46,7 @@
                         </span>
                     </td>
                     <td class="action-icons">
+                        <a th:href="@{/buildings/{id}(id=${summary.id()})}" class="view" title="Xem chi tiết"><i class="fas fa-eye"></i></a>
                         <a th:href="@{/buildings/{id}/edit(id=${summary.id()})}" class="edit" title="Chỉnh sửa"><i class="fas fa-edit"></i></a>
                         <a th:href="@{/buildings/{id}/delete(id=${summary.id()})}" class="delete" title="Xóa" onclick="return confirm('Bạn có chắc muốn xóa tòa này?')"><i class="fas fa-trash"></i></a>
                     </td>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -47,51 +47,38 @@
             <a class="login-link" th:href="@{/login}" sec:authorize="!isAuthenticated()">Đăng nhập</a>
         </div>
     </header>
-</div>
 
-<div th:fragment="popup" xmlns:th="http://www.thymeleaf.org">
-    <div id="popup-message" th:if="${message}" th:class="'popup-alert ' + ${alertClass}" style="display:none;">
-        <span th:text="${message}"></span>
-    </div>
     <script>
-        function closePopup() {
-            const popup = document.getElementById('popup-message');
-            if (popup) {
-                popup.style.display = 'none';
-            }
-        }
-        window.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function() {
             const popup = document.getElementById('popup-message');
             if (popup) {
                 popup.style.display = 'flex';
-                setTimeout(function() { popup.style.display = 'none'; }, 3000);
+                window.setTimeout(function() {
+                    popup.style.display = 'none';
+                }, 3000);
             }
 
-            const userProfile = document.querySelector('.user-profile');
-            if (userProfile) {
+            const initUserProfile = (userProfile) => {
                 const trigger = userProfile.querySelector('.user-trigger');
                 const dropdown = userProfile.querySelector('.user-dropdown');
+                if (!trigger || !dropdown) {
+                    return;
+                }
+
                 const toggleMenu = (expand) => {
                     const isOpen = expand !== undefined ? expand : !userProfile.classList.contains('open');
                     userProfile.classList.toggle('open', isOpen);
-                    if (trigger) {
-                        trigger.setAttribute('aria-expanded', isOpen);
-                    }
-                    if (dropdown) {
-                        dropdown.hidden = !isOpen;
-                    }
+                    trigger.setAttribute('aria-expanded', String(isOpen));
+                    dropdown.hidden = !isOpen;
                 };
 
-                if (dropdown) {
-                    dropdown.hidden = true;
-                }
+                dropdown.hidden = true;
 
-                if (trigger) {
-                    trigger.addEventListener('click', (event) => {
-                        event.stopPropagation();
-                        toggleMenu();
-                    });
-                }
+                trigger.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    toggleMenu();
+                });
 
                 document.addEventListener('click', (event) => {
                     if (!userProfile.contains(event.target)) {
@@ -104,7 +91,15 @@
                         toggleMenu(false);
                     }
                 });
-            }
+            };
+
+            document.querySelectorAll('.user-profile').forEach(initUserProfile);
         });
     </script>
+</div>
+
+<div th:fragment="popup" xmlns:th="http://www.thymeleaf.org">
+    <div id="popup-message" th:if="${message}" th:class="'popup-alert ' + ${alertClass}" style="display:none;">
+        <span th:text="${message}"></span>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- add DTOs, service logic, repository query, and a new Thymeleaf template to display detailed building information and room occupancy
- link the building list to the new detail page and extend styling for the richer layout
- move the header dropdown script into the header fragment so the profile menu works reliably on every page

## Testing
- mvn -q test *(fails: Non-resolvable parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e65f65748c83268abbf91418718d4f